### PR TITLE
feat: mount machu picchu canvas in the hero scene

### DIFF
--- a/apps/web/components/landing/hero-scene.test.ts
+++ b/apps/web/components/landing/hero-scene.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+
+import {
+  HERO_SCENE_MODEL_URL,
+  HERO_SCENE_ROOT_ID,
+  HERO_SCENE_THEME,
+} from "./hero-scene";
+
+test("exports the locked Machu Picchu mount contract", () => {
+  expect(HERO_SCENE_ROOT_ID).toBe("hero-scene");
+  expect(HERO_SCENE_THEME).toBe("machu-picchu");
+  expect(HERO_SCENE_MODEL_URL).toBe("/models/machu-picchu.glb");
+});

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -1,90 +1,183 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
 import { facts } from "@/components/landing/content";
 import { HeroScene } from "@/components/landing/hero-scene";
-import { HudLabel } from "@/components/landing/hud";
+import { DeviceCard, HudLabel } from "@/components/landing/hud";
+import {
+  chapterFromProgress,
+  type ProjectedTarget,
+  type WorldChapter,
+} from "@/components/landing/machu-picchu-geometry";
+import { MachuPicchuScene } from "@/components/landing/machu-picchu-scene";
+import { ScanHud } from "@/components/landing/scan-hud";
 import {
   landingCtaClassName,
   landingDisplayClassName,
 } from "@/components/landing/shell";
 
+function readProgress(section: HTMLElement): number {
+  const total = section.offsetHeight - window.innerHeight;
+  if (total <= 0) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, -section.getBoundingClientRect().top / total));
+}
+
 export function LandingHero() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const progressRef = useRef(0);
+  const [chapter, setChapter] = useState<WorldChapter>("hero");
+  const [targets, setTargets] = useState<ProjectedTarget[]>([]);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) {
+      return;
+    }
+
+    const update = () => {
+      const next = readProgress(section);
+      progressRef.current = next;
+      const nextChapter = chapterFromProgress(next);
+      setChapter((current) => {
+        if (current === nextChapter) {
+          return current;
+        }
+        return nextChapter;
+      });
+    };
+
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  const heroVisible = chapter === "hero";
+  const valleyVisible = chapter === "valley";
+  const scanVisible = chapter === "scan";
+
+  let heroOpacity = "opacity-0";
+  if (heroVisible) {
+    heroOpacity = "opacity-100";
+  }
+
+  let valleyClass = "pointer-events-none opacity-0 translate-y-3";
+  if (valleyVisible) {
+    valleyClass = "opacity-100 translate-y-0";
+  }
+
   return (
-    <section className="relative min-h-dvh w-full overflow-hidden bg-[#0b0d10] md:h-dvh">
-      <HeroScene />
+    <section
+      ref={sectionRef}
+      className="relative w-full overflow-hidden bg-[#0b0d10]"
+      id="world"
+    >
+      <div className="sticky top-0 h-dvh overflow-hidden">
+        <HeroScene>
+          <MachuPicchuScene onTargets={setTargets} progressRef={progressRef} />
+        </HeroScene>
 
-      <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-b from-[#0b0d10]/55 via-transparent to-[#0b0d10]/70" />
-      <div className="pointer-events-none absolute inset-0 z-10 hud-scanlines" />
+        <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-b from-[#0b0d10]/45 via-transparent to-[#0b0d10]/55" />
+        <div className="pointer-events-none absolute inset-0 z-10 hud-scanlines" />
 
-      <div className="pointer-events-none relative z-20 mx-auto flex min-h-dvh w-full max-w-[1800px] flex-col justify-between px-4 pt-6 pb-8 sm:px-8 md:h-dvh">
-        <div className="flex items-start justify-between gap-4">
-          <HudLabel className="text-[#d6ff00]">
-            {"hta / world-01 / machu picchu"}
-          </HudLabel>
-          <HudLabel className="text-[#f5f5f5]/70">nav unlocked</HudLabel>
-        </div>
-
-        <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
-          <div className="max-w-4xl">
-            <p className="mb-4 inline-block bg-[#0057ff] px-3 py-1 font-[family-name:var(--font-landing-mono)] text-[10px] tracking-[0.2em] text-[#f5f5f5] uppercase">
-              best of the best · lima
-            </p>
-            <h1 className="max-w-[12ch]">
-              <span
-                className={`${landingDisplayClassName} block text-[clamp(4.6rem,16vw,12rem)] text-[#f5f5f5]`}
-              >
-                hack the
-              </span>
-              <span
-                className={`${landingDisplayClassName} block text-[clamp(4.6rem,16vw,12rem)] text-[#d6ff00]`}
-              >
-                andes
-              </span>
-            </h1>
-            <p className="mt-5 max-w-xl text-sm leading-relaxed text-[#f5f5f5]/80 sm:text-base">
-              Hackathon selectivo de IA · Lima, Perú · 10–11 oct 2026
-            </p>
+        <div
+          className={`pointer-events-none relative z-20 mx-auto flex h-dvh w-full max-w-[1800px] flex-col justify-between px-4 pt-6 pb-8 transition-opacity duration-500 sm:px-8 ${heroOpacity}`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <HudLabel className="text-[#d6ff00]">
+              {"hta / world-01 / machu picchu"}
+            </HudLabel>
+            <HudLabel className="text-[#f5f5f5]/70">nav unlocked</HudLabel>
           </div>
 
-          <a
-            className={`pointer-events-auto w-full lg:w-auto ${landingCtaClassName}`}
-            href="#apply"
-          >
-            <span>Aplicar ahora</span>
-            <span className="mt-1 text-[10px] tracking-[0.16em] text-[#0b0d10]/70">
-              10–11 oct 2026 · presencial
-            </span>
-          </a>
-        </div>
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-4xl">
+              <p className="mb-4 inline-block bg-[#0057ff] px-3 py-1 font-[family-name:var(--font-landing-mono)] text-[10px] tracking-[0.2em] text-[#f5f5f5] uppercase">
+                best of the best · lima
+              </p>
+              <h1 className="max-w-[12ch]">
+                <span
+                  className={`${landingDisplayClassName} block text-[clamp(4.6rem,16vw,12rem)] text-[#f5f5f5]`}
+                >
+                  hack the
+                </span>
+                <span
+                  className={`${landingDisplayClassName} block text-[clamp(4.6rem,16vw,12rem)] text-[#d6ff00]`}
+                >
+                  andes
+                </span>
+              </h1>
+              <p className="mt-5 max-w-xl text-sm leading-relaxed text-[#f5f5f5]/80 sm:text-base">
+                Hackathon selectivo de IA · Lima, Perú · 10–11 oct 2026
+              </p>
+            </div>
 
-        <div className="flex flex-col gap-5">
-          <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-            {facts.map((fact) => (
-              <li
-                className="hud-box bg-[#0b0d10]/45 px-3 py-3 backdrop-blur-[2px]"
-                key={fact.label}
-              >
-                <HudLabel className="mb-1 text-[#d6ff00]">
-                  {fact.label}
-                </HudLabel>
-                <p className="font-[family-name:var(--font-landing-display)] text-xl uppercase leading-none">
-                  {fact.value}
-                </p>
-              </li>
-            ))}
-          </ul>
-
-          <div className="flex items-end justify-between gap-4">
-            <p className="font-[family-name:var(--font-landing-mono)] text-[10px] tracking-[0.18em] text-[#f5f5f5]/75 uppercase">
-              sponsored by chofex
-            </p>
-            <a className="pointer-events-auto text-[#d6ff00]" href="#judges">
-              <span className="sr-only">Aplicar abajo</span>
-              <span aria-hidden="true" className="block text-3xl leading-none">
-                ⌄
+            <a
+              className={`pointer-events-auto w-full lg:w-auto ${landingCtaClassName}`}
+              href="#apply"
+            >
+              <span>Aplicar ahora</span>
+              <span className="mt-1 text-[10px] tracking-[0.16em] text-[#0b0d10]/70">
+                10–11 oct 2026 · presencial
               </span>
             </a>
           </div>
+
+          <div className="flex flex-col gap-5">
+            <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {facts.map((fact) => (
+                <li
+                  className="hud-box bg-[#0b0d10]/45 px-3 py-3 backdrop-blur-[2px]"
+                  key={fact.label}
+                >
+                  <HudLabel className="mb-1 text-[#d6ff00]">
+                    {fact.label}
+                  </HudLabel>
+                  <p className="font-[family-name:var(--font-landing-display)] text-xl leading-none uppercase">
+                    {fact.value}
+                  </p>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex items-end justify-between gap-4">
+              <p className="font-[family-name:var(--font-landing-mono)] text-[10px] tracking-[0.18em] text-[#f5f5f5]/75 uppercase">
+                sponsored by chofex
+              </p>
+              <a className="pointer-events-auto text-[#d6ff00]" href="#judges">
+                <span className="sr-only">Bajar a jueces</span>
+                <span
+                  aria-hidden="true"
+                  className="block text-3xl leading-none"
+                >
+                  ⌄
+                </span>
+              </a>
+            </div>
+          </div>
         </div>
+
+        <aside
+          className={`absolute right-4 bottom-24 z-20 w-[min(22rem,calc(100%-2rem))] transition duration-500 sm:right-8 ${valleyClass}`}
+        >
+          <DeviceCard
+            accent="yellow"
+            body="Filtra por rigor. Si el sistema no aguanta, no entra."
+            code="J-01"
+            handle="QUISPE"
+            title="Juez 01 · IA aplicada"
+          />
+        </aside>
+
+        <ScanHud targets={targets} visible={scanVisible} />
       </div>
+      <div aria-hidden="true" className="h-[320vh]" />
     </section>
   );
 }

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -83,7 +83,7 @@ export function LandingHero() {
           <MachuPicchuScene onTargets={setTargets} progressRef={progressRef} />
         </HeroScene>
 
-        <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-b from-[#0b0d10]/45 via-transparent to-[#0b0d10]/55" />
+        <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-b from-[#0b0d10]/18 via-transparent to-[#0b0d10]/28" />
         <div className="pointer-events-none absolute inset-0 z-10 hud-scanlines" />
 
         <div

--- a/apps/web/components/landing/landing.css
+++ b/apps/web/components/landing/landing.css
@@ -117,6 +117,25 @@
   animation: landing-scan 3.6s ease-in-out infinite;
 }
 
+.landing-scan-box {
+  position: absolute;
+  border: 1px solid #d6ff00;
+  box-shadow: 0 0 0 1px rgb(0 87 255 / 55%);
+  pointer-events: none;
+}
+
+.landing-scan-box__label {
+  position: absolute;
+  top: -1.15rem;
+  left: -1px;
+  background: #d6ff00;
+  color: #0b0d10;
+  padding: 0.1rem 0.35rem;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .landing-scan-beam {
     animation: none;

--- a/apps/web/components/landing/machu-picchu-canvas.tsx
+++ b/apps/web/components/landing/machu-picchu-canvas.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { AdaptiveDpr } from "@react-three/drei";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { type MutableRefObject, Suspense, useRef } from "react";
+import * as THREE from "three";
+
+import {
+  chapterFromProgress,
+  type ProjectedTarget,
+  sampleCameraPath,
+  WORLD_FIGURES,
+} from "@/components/landing/machu-picchu-geometry";
+import { MachuPicchuAsset } from "@/components/landing/machu-picchu-model";
+
+const LOOK = new THREE.Vector3();
+const PROJECT = new THREE.Vector3();
+
+type SceneQuality = "low" | "high";
+
+export type MachuPicchuCanvasProps = {
+  readonly quality: SceneQuality;
+  readonly progressRef: MutableRefObject<number>;
+  readonly visible?: boolean;
+  readonly onContextLost?: () => void;
+  readonly onTargets?: (targets: ProjectedTarget[]) => void;
+};
+
+function WorldLights({ quality }: { readonly quality: SceneQuality }) {
+  const mapSize = quality === "high" ? 2048 : 512;
+
+  return (
+    <>
+      <color args={["#0a3dff"]} attach="background" />
+      <fog attach="fog" args={["#3d7dff", 40, 220]} />
+      <ambientLight color="#9ec4ff" intensity={0.42} />
+      <hemisphereLight args={["#7eb6ff", "#2a3550", 0.55]} />
+      <directionalLight
+        castShadow={quality === "high"}
+        color="#ffe566"
+        intensity={1.85}
+        position={[-48, 62, 28]}
+        shadow-bias={-0.0004}
+        shadow-camera-bottom={-50}
+        shadow-camera-far={180}
+        shadow-camera-left={-50}
+        shadow-camera-near={8}
+        shadow-camera-right={50}
+        shadow-camera-top={50}
+        shadow-mapSize={[mapSize, mapSize]}
+      />
+      <directionalLight
+        color="#e8ff00"
+        intensity={0.22}
+        position={[36, 18, -24]}
+      />
+    </>
+  );
+}
+
+function ValleyFigures({ quality }: { readonly quality: SceneQuality }) {
+  return (
+    <group>
+      <mesh position={[6, 0.04, 8.6]} receiveShadow={quality === "high"}>
+        <cylinderGeometry args={[16, 16, 0.12, 48]} />
+        <meshStandardMaterial color="#dfe6f2" roughness={0.62} />
+      </mesh>
+      {WORLD_FIGURES.map((figure) => {
+        const isJudge = figure.kind === "judge";
+        let accent = "#ffffff";
+        if (isJudge) {
+          accent = "#e8ff00";
+        }
+        return (
+          <group key={figure.id} position={figure.position}>
+            <mesh castShadow={quality === "high"} position={[0, 1.15, 0]}>
+              <capsuleGeometry args={[0.28, 0.95, 6, 12]} />
+              <meshStandardMaterial color="#f7f9ff" roughness={0.35} />
+            </mesh>
+            <mesh castShadow={quality === "high"} position={[0, 2.05, 0]}>
+              <sphereGeometry args={[0.26, 16, 16]} />
+              <meshStandardMaterial color={accent} roughness={0.28} />
+            </mesh>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+function ExploreCamera({
+  progressRef,
+  quality,
+  onTargets,
+}: {
+  readonly progressRef: MutableRefObject<number>;
+  readonly quality: SceneQuality;
+  readonly onTargets?: (targets: ProjectedTarget[]) => void;
+}) {
+  const { camera, size, pointer } = useThree();
+  const frame = useRef(0);
+
+  useFrame(({ clock }) => {
+    const progress = progressRef.current;
+    const path = sampleCameraPath(progress);
+    const chapter = chapterFromProgress(progress);
+    const time = clock.elapsedTime;
+    const explore = Math.max(0, 1 - progress / 0.24);
+    const portrait = size.height > size.width;
+    const orbit = Math.sin(time * 0.07) * 0.16 * explore;
+    const pointerYaw = pointer.x * 0.42 * explore;
+    const pointerPitch = pointer.y * 0.1 * explore;
+
+    let radiusBoost = 0;
+    if (portrait && chapter === "hero") {
+      radiusBoost = 14;
+    }
+
+    camera.position.set(
+      path.position[0] + Math.sin(orbit + pointerYaw) * (8 + radiusBoost),
+      path.position[1] +
+        pointerPitch * 6 +
+        Math.sin(time * 0.05) * 0.55 * explore,
+      path.position[2] + Math.cos(orbit + pointerYaw) * (6 + radiusBoost * 0.4),
+    );
+    LOOK.set(path.lookAt[0], path.lookAt[1], path.lookAt[2]);
+    camera.lookAt(LOOK);
+
+    if (!onTargets) {
+      return;
+    }
+
+    frame.current += 1;
+    const sampleEvery = quality === "high" ? 2 : 4;
+    if (frame.current % sampleEvery !== 0) {
+      return;
+    }
+
+    const targets = WORLD_FIGURES.map((figure) => {
+      PROJECT.set(
+        figure.position[0],
+        figure.position[1] + 1.6,
+        figure.position[2],
+      );
+      PROJECT.project(camera);
+      const x = (PROJECT.x * 0.5 + 0.5) * 100;
+      const y = (-PROJECT.y * 0.5 + 0.5) * 100;
+      const inFront = PROJECT.z > -1 && PROJECT.z < 1;
+      const onScreen = x > -4 && x < 104 && y > -4 && y < 104;
+      return {
+        id: figure.id,
+        kind: figure.kind,
+        label: figure.label,
+        x,
+        y,
+        visible: inFront && onScreen,
+      };
+    });
+    onTargets(targets);
+  });
+
+  return null;
+}
+
+function MachuWorld({
+  quality,
+  progressRef,
+  onTargets,
+}: {
+  readonly quality: SceneQuality;
+  readonly progressRef: MutableRefObject<number>;
+  readonly onTargets?: (targets: ProjectedTarget[]) => void;
+}) {
+  return (
+    <>
+      <WorldLights quality={quality} />
+      <Suspense fallback={null}>
+        <MachuPicchuAsset quality={quality} />
+      </Suspense>
+      <ValleyFigures quality={quality} />
+      <ExploreCamera
+        onTargets={onTargets}
+        progressRef={progressRef}
+        quality={quality}
+      />
+      <AdaptiveDpr pixelated={false} />
+    </>
+  );
+}
+
+export function MachuPicchuCanvas({
+  quality,
+  progressRef,
+  visible = true,
+  onContextLost,
+  onTargets,
+}: MachuPicchuCanvasProps) {
+  return (
+    <Canvas
+      camera={{ far: 420, fov: 42, near: 0.1, position: [92, 40, 108] }}
+      className="pointer-events-none absolute inset-0 size-full"
+      dpr={quality === "high" ? [1, 1.5] : [1, 1]}
+      frameloop={visible ? "always" : "never"}
+      gl={{
+        alpha: false,
+        antialias: quality === "high",
+        powerPreference: "high-performance",
+      }}
+      onCreated={({ gl }) => {
+        gl.setClearColor("#0a3dff");
+        gl.domElement.style.pointerEvents = "none";
+        gl.domElement.addEventListener(
+          "webglcontextlost",
+          (event) => {
+            event.preventDefault();
+            onContextLost?.();
+          },
+          { once: true },
+        );
+      }}
+      shadows={quality === "high"}
+      style={{ pointerEvents: "none" }}
+    >
+      <MachuWorld
+        onTargets={onTargets}
+        progressRef={progressRef}
+        quality={quality}
+      />
+    </Canvas>
+  );
+}

--- a/apps/web/components/landing/machu-picchu-canvas.tsx
+++ b/apps/web/components/landing/machu-picchu-canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AdaptiveDpr } from "@react-three/drei";
+import { AdaptiveDpr, Sparkles } from "@react-three/drei";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { type MutableRefObject, Suspense, useRef } from "react";
 import * as THREE from "three";
@@ -31,15 +31,15 @@ function WorldLights({ quality }: { readonly quality: SceneQuality }) {
 
   return (
     <>
-      <color args={["#0a3dff"]} attach="background" />
-      <fog attach="fog" args={["#3d7dff", 40, 220]} />
-      <ambientLight color="#9ec4ff" intensity={0.42} />
-      <hemisphereLight args={["#7eb6ff", "#2a3550", 0.55]} />
+      <color args={["#1a4fd8"]} attach="background" />
+      <fog attach="fog" args={["#4d86e8", 28, 160]} />
+      <ambientLight color="#ffd7a8" intensity={0.22} />
+      <hemisphereLight args={["#8ec4ff", "#3a2a18", 0.62]} />
       <directionalLight
         castShadow={quality === "high"}
-        color="#ffe566"
-        intensity={1.85}
-        position={[-48, 62, 28]}
+        color="#ffc878"
+        intensity={2.35}
+        position={[-38, 28, 46]}
         shadow-bias={-0.0004}
         shadow-camera-bottom={-50}
         shadow-camera-far={180}
@@ -50,11 +50,75 @@ function WorldLights({ quality }: { readonly quality: SceneQuality }) {
         shadow-mapSize={[mapSize, mapSize]}
       />
       <directionalLight
-        color="#e8ff00"
-        intensity={0.22}
-        position={[36, 18, -24]}
+        color="#d6ff00"
+        intensity={0.18}
+        position={[42, 16, -30]}
+      />
+      <pointLight
+        color="#ffb35c"
+        intensity={18}
+        position={[8, 6, 10]}
+        distance={42}
       />
     </>
+  );
+}
+
+function HeroSparkles({ quality }: { readonly quality: SceneQuality }) {
+  if (quality !== "high") {
+    return null;
+  }
+
+  return (
+    <Sparkles
+      color="#fff4d2"
+      count={90}
+      opacity={0.55}
+      position={[4, 10, 6]}
+      scale={[36, 14, 36]}
+      size={3.2}
+      speed={0.18}
+    />
+  );
+}
+
+function DriftDiscs({ quality }: { readonly quality: SceneQuality }) {
+  const group = useRef<THREE.Group>(null);
+  const discs = [
+    { color: "#f4f7fb", position: [-10, 8, 16] as const, radius: 1.6 },
+    { color: "#d6ff00", position: [14, 11, 8] as const, radius: 1.1 },
+    { color: "#ffe4b0", position: [6, 14, 22] as const, radius: 0.85 },
+  ];
+
+  useFrame(({ clock }) => {
+    const node = group.current;
+    if (!node) {
+      return;
+    }
+    const time = clock.elapsedTime;
+    node.children.forEach((child, index) => {
+      child.position.y = discs[index]?.position[1] ?? 8;
+      child.position.y += Math.sin(time * 0.35 + index * 1.3) * 0.7;
+      child.rotation.y = time * 0.12 + index;
+      child.rotation.x = Math.sin(time * 0.18 + index) * 0.2;
+    });
+  });
+
+  return (
+    <group ref={group}>
+      {discs.map((disc) => (
+        <mesh key={disc.color} position={disc.position}>
+          <cylinderGeometry args={[disc.radius, disc.radius, 0.18, 32]} />
+          <meshPhysicalMaterial
+            clearcoat={quality === "high" ? 0.85 : 0}
+            clearcoatRoughness={0.18}
+            color={disc.color}
+            metalness={0.12}
+            roughness={0.22}
+          />
+        </mesh>
+      ))}
+    </group>
   );
 }
 
@@ -69,17 +133,25 @@ function ValleyFigures({ quality }: { readonly quality: SceneQuality }) {
         const isJudge = figure.kind === "judge";
         let accent = "#ffffff";
         if (isJudge) {
-          accent = "#e8ff00";
+          accent = "#d6ff00";
         }
         return (
           <group key={figure.id} position={figure.position}>
             <mesh castShadow={quality === "high"} position={[0, 1.15, 0]}>
               <capsuleGeometry args={[0.28, 0.95, 6, 12]} />
-              <meshStandardMaterial color="#f7f9ff" roughness={0.35} />
+              <meshPhysicalMaterial
+                clearcoat={0.55}
+                color="#f7f9ff"
+                roughness={0.28}
+              />
             </mesh>
             <mesh castShadow={quality === "high"} position={[0, 2.05, 0]}>
               <sphereGeometry args={[0.26, 16, 16]} />
-              <meshStandardMaterial color={accent} roughness={0.28} />
+              <meshPhysicalMaterial
+                clearcoat={0.7}
+                color={accent}
+                roughness={0.18}
+              />
             </mesh>
           </group>
         );
@@ -106,10 +178,11 @@ function ExploreCamera({
     const chapter = chapterFromProgress(progress);
     const time = clock.elapsedTime;
     const explore = Math.max(0, 1 - progress / 0.24);
+    const drift = 0.4 + explore * 0.6;
     const portrait = size.height > size.width;
-    const orbit = Math.sin(time * 0.07) * 0.16 * explore;
-    const pointerYaw = pointer.x * 0.42 * explore;
-    const pointerPitch = pointer.y * 0.1 * explore;
+    const orbit = Math.sin(time * 0.055) * 0.26 * drift;
+    const pointerYaw = pointer.x * 0.48 * explore;
+    const pointerPitch = pointer.y * 0.12 * explore;
 
     let radiusBoost = 0;
     if (portrait && chapter === "hero") {
@@ -119,8 +192,8 @@ function ExploreCamera({
     camera.position.set(
       path.position[0] + Math.sin(orbit + pointerYaw) * (8 + radiusBoost),
       path.position[1] +
-        pointerPitch * 6 +
-        Math.sin(time * 0.05) * 0.55 * explore,
+        pointerPitch * 7 +
+        Math.sin(time * 0.045) * 0.85 * drift,
       path.position[2] + Math.cos(orbit + pointerYaw) * (6 + radiusBoost * 0.4),
     );
     LOOK.set(path.lookAt[0], path.lookAt[1], path.lookAt[2]);
@@ -178,6 +251,8 @@ function MachuWorld({
         <MachuPicchuAsset quality={quality} />
       </Suspense>
       <ValleyFigures quality={quality} />
+      <DriftDiscs quality={quality} />
+      <HeroSparkles quality={quality} />
       <ExploreCamera
         onTargets={onTargets}
         progressRef={progressRef}
@@ -197,7 +272,7 @@ export function MachuPicchuCanvas({
 }: MachuPicchuCanvasProps) {
   return (
     <Canvas
-      camera={{ far: 420, fov: 42, near: 0.1, position: [92, 40, 108] }}
+      camera={{ far: 420, fov: 38, near: 0.1, position: [46, 18, 58] }}
       className="pointer-events-none absolute inset-0 size-full"
       dpr={quality === "high" ? [1, 1.5] : [1, 1]}
       frameloop={visible ? "always" : "never"}
@@ -207,7 +282,9 @@ export function MachuPicchuCanvas({
         powerPreference: "high-performance",
       }}
       onCreated={({ gl }) => {
-        gl.setClearColor("#0a3dff");
+        gl.toneMapping = THREE.ACESFilmicToneMapping;
+        gl.toneMappingExposure = 1.18;
+        gl.setClearColor("#1a4fd8");
         gl.domElement.style.pointerEvents = "none";
         gl.domElement.addEventListener(
           "webglcontextlost",

--- a/apps/web/components/landing/machu-picchu-geometry.test.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.test.ts
@@ -36,6 +36,7 @@ test("keeps the camera path descending into the valley", () => {
   const hero = sampleCameraPath(0);
   const valley = sampleCameraPath(0.5);
   const scan = sampleCameraPath(0.9);
+  expect(hero.position[1]).toBeLessThan(24);
   expect(valley.position[1]).toBeLessThan(hero.position[1]);
   expect(scan.position[2]).toBeLessThan(hero.position[2]);
 });

--- a/apps/web/components/landing/machu-picchu-geometry.test.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+
+import { HERO_SCENE_MODEL_URL } from "./hero-scene";
+import {
+  chapterFromProgress,
+  MACHU_MODEL_SCALE,
+  MACHU_PICCHU_GLB,
+  MACHU_SOURCE_BBOX,
+  sampleCameraPath,
+  scaledSourceSize,
+  WORLD_FIGURES,
+} from "./machu-picchu-geometry";
+
+test("points the hero model at the public glb path", () => {
+  expect(MACHU_PICCHU_GLB).toBe(HERO_SCENE_MODEL_URL);
+  expect(HERO_SCENE_MODEL_URL).toBe("/models/machu-picchu.glb");
+  expect(MACHU_MODEL_SCALE).toBeGreaterThan(0);
+  expect(MACHU_SOURCE_BBOX.max[1]).toBeGreaterThan(MACHU_SOURCE_BBOX.min[1]);
+});
+
+test("scales the source bbox into a navigable hero volume", () => {
+  const size = scaledSourceSize();
+  expect(size.width).toBeGreaterThan(100);
+  expect(size.width).toBeLessThan(200);
+  expect(size.height).toBeGreaterThan(20);
+  expect(size.height).toBeLessThan(80);
+});
+
+test("maps scroll progress onto hero, valley, and scan chapters", () => {
+  expect(chapterFromProgress(0)).toBe("hero");
+  expect(chapterFromProgress(0.4)).toBe("valley");
+  expect(chapterFromProgress(0.8)).toBe("scan");
+});
+
+test("keeps the camera path descending into the valley", () => {
+  const hero = sampleCameraPath(0);
+  const valley = sampleCameraPath(0.5);
+  const scan = sampleCameraPath(0.9);
+  expect(valley.position[1]).toBeLessThan(hero.position[1]);
+  expect(scan.position[2]).toBeLessThan(hero.position[2]);
+});
+
+test("places figures for the valley and scan chapters", () => {
+  expect(WORLD_FIGURES.some((figure) => figure.kind === "judge")).toBe(true);
+  expect(WORLD_FIGURES.length).toBeGreaterThan(3);
+});

--- a/apps/web/components/landing/machu-picchu-geometry.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.ts
@@ -41,11 +41,11 @@ const CAMERA_STOPS: ReadonlyArray<{
 }> = [
   {
     progress: 0,
-    frame: { position: [92, 40, 108], lookAt: [0, 14, -6] },
+    frame: { position: [46, 18, 58], lookAt: [2, 9, -4] },
   },
   {
     progress: 0.22,
-    frame: { position: [58, 28, 72], lookAt: [2, 12, -2] },
+    frame: { position: [34, 14, 42], lookAt: [3, 8, -1] },
   },
   {
     progress: 0.46,

--- a/apps/web/components/landing/machu-picchu-geometry.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.ts
@@ -1,0 +1,254 @@
+import { HERO_SCENE_MODEL_URL } from "@/components/landing/hero-scene";
+
+/** Same public URL the HeroScene mount advertises. */
+export const MACHU_PICCHU_GLB = HERO_SCENE_MODEL_URL;
+
+/** Source-space bbox of the provided export (units before scene scale). */
+export const MACHU_SOURCE_BBOX = {
+  min: [-2025, 0, -2017],
+  max: [2025, 1101, 2017],
+} as const;
+
+/** Fits the ~4 km source mesh into a navigable hero volume. */
+export const MACHU_MODEL_SCALE = 0.036;
+
+export type WorldChapter = "hero" | "valley" | "scan";
+
+export type CameraKeyframe = {
+  position: [number, number, number];
+  lookAt: [number, number, number];
+};
+
+export type WorldFigure = {
+  id: string;
+  kind: "judge" | "candidate";
+  label: string;
+  position: [number, number, number];
+};
+
+export type ProjectedTarget = {
+  id: string;
+  kind: "judge" | "candidate";
+  label: string;
+  x: number;
+  y: number;
+  visible: boolean;
+};
+
+const CAMERA_STOPS: ReadonlyArray<{
+  progress: number;
+  frame: CameraKeyframe;
+}> = [
+  {
+    progress: 0,
+    frame: { position: [92, 40, 108], lookAt: [0, 14, -6] },
+  },
+  {
+    progress: 0.22,
+    frame: { position: [58, 28, 72], lookAt: [2, 12, -2] },
+  },
+  {
+    progress: 0.46,
+    frame: { position: [20, 9.5, 38], lookAt: [5.2, 2.6, 8.4] },
+  },
+  {
+    progress: 0.74,
+    frame: { position: [13, 7.8, 22], lookAt: [4.4, 2.3, 7.2] },
+  },
+  {
+    progress: 1,
+    frame: { position: [11, 8.4, 18], lookAt: [4.8, 2.5, 7.6] },
+  },
+];
+
+export const WORLD_FIGURES: readonly WorldFigure[] = [
+  { id: "j-01", kind: "judge", label: "QUISPE", position: [5.2, 0, 9.1] },
+  { id: "j-02", kind: "judge", label: "VALLE", position: [9.8, 0, 8.4] },
+  { id: "c-01", kind: "candidate", label: "TALENTO", position: [7.4, 0, 6.8] },
+  { id: "c-02", kind: "candidate", label: "SIGNAL", position: [2.6, 0, 10.6] },
+  {
+    id: "c-03",
+    kind: "candidate",
+    label: "CANDIDATO",
+    position: [8.8, 0, 11.4],
+  },
+  { id: "c-04", kind: "candidate", label: "BEST OF", position: [3.8, 0, 6.4] },
+];
+
+export function chapterFromProgress(progress: number): WorldChapter {
+  if (progress < 0.34) {
+    return "hero";
+  }
+  if (progress < 0.64) {
+    return "valley";
+  }
+  return "scan";
+}
+
+export function clamp01(value: number): number {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}
+
+export function smoothstep(
+  edge0: number,
+  edge1: number,
+  value: number,
+): number {
+  const t = clamp01((value - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+export function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
+}
+
+export function lerpTriple(
+  from: readonly [number, number, number],
+  to: readonly [number, number, number],
+  t: number,
+): [number, number, number] {
+  return [
+    lerp(from[0], to[0], t),
+    lerp(from[1], to[1], t),
+    lerp(from[2], to[2], t),
+  ];
+}
+
+export function sampleCameraPath(progress: number): CameraKeyframe {
+  const p = clamp01(progress);
+  let start = CAMERA_STOPS[0];
+  let end = CAMERA_STOPS[CAMERA_STOPS.length - 1];
+
+  for (let index = 0; index < CAMERA_STOPS.length - 1; index += 1) {
+    const current = CAMERA_STOPS[index];
+    const next = CAMERA_STOPS[index + 1];
+    if (!current || !next) {
+      continue;
+    }
+    if (p >= current.progress && p <= next.progress) {
+      start = current;
+      end = next;
+      break;
+    }
+  }
+
+  if (!start || !end) {
+    return { position: [92, 40, 108], lookAt: [0, 14, -6] };
+  }
+
+  const span = end.progress - start.progress;
+  let t = 0;
+  if (span > 0) {
+    t = smoothstep(0, 1, (p - start.progress) / span);
+  }
+
+  return {
+    position: lerpTriple(start.frame.position, end.frame.position, t),
+    lookAt: lerpTriple(start.frame.lookAt, end.frame.lookAt, t),
+  };
+}
+
+export function scaledSourceSize(): {
+  width: number;
+  height: number;
+  depth: number;
+} {
+  const width =
+    (MACHU_SOURCE_BBOX.max[0] - MACHU_SOURCE_BBOX.min[0]) * MACHU_MODEL_SCALE;
+  const height =
+    (MACHU_SOURCE_BBOX.max[1] - MACHU_SOURCE_BBOX.min[1]) * MACHU_MODEL_SCALE;
+  const depth =
+    (MACHU_SOURCE_BBOX.max[2] - MACHU_SOURCE_BBOX.min[2]) * MACHU_MODEL_SCALE;
+  return { width, height, depth };
+}
+
+function hash2(x: number, y: number): number {
+  const n = Math.sin(x * 127.1 + y * 311.7) * 43758.5453;
+  return n - Math.floor(n);
+}
+
+function valueNoise(x: number, y: number): number {
+  const ix = Math.floor(x);
+  const iy = Math.floor(y);
+  const fx = x - ix;
+  const fy = y - iy;
+  const ux = fx * fx * (3 - 2 * fx);
+  const uy = fy * fy * (3 - 2 * fy);
+
+  return (
+    hash2(ix, iy) * (1 - ux) * (1 - uy) +
+    hash2(ix + 1, iy) * ux * (1 - uy) +
+    hash2(ix, iy + 1) * (1 - ux) * uy +
+    hash2(ix + 1, iy + 1) * ux * uy
+  );
+}
+
+export function ridgeHeight(x: number, z: number): number {
+  const noise = valueNoise(x * 0.04 + 3, z * 0.04 + 8);
+  const huaynaDist = Math.hypot(x - 6, z + 38);
+  const huayna = Math.max(0, 1 - huaynaDist / 20) ** 1.55 * 36;
+  const saddleX = Math.exp(-(((x + 1) / 24) ** 2));
+  const saddleZ = Math.exp(-(((z + 4) / 16) ** 2));
+  const saddle = saddleX * saddleZ * 18;
+  const valleyDrop = Math.max(0, x - 16) * 0.28 + Math.max(0, z - 8) * 0.18;
+
+  let height = 4 + saddle + huayna + noise * 2.4 - valleyDrop;
+
+  const plaza = Math.hypot(x - 6, z - 9);
+  if (plaza < 14) {
+    height = Math.max(0.15, height * 0.22);
+  }
+
+  return height;
+}
+
+export type CitadelBlock = {
+  position: [number, number, number];
+  size: [number, number, number];
+};
+
+export function buildCitadelBlocks(): CitadelBlock[] {
+  const blocks: CitadelBlock[] = [];
+  const originX = -4;
+  const originZ = -6;
+
+  for (let row = 0; row < 6; row += 1) {
+    for (let col = 0; col < 8; col += 1) {
+      const skip = (row + col) % 5 === 0;
+      if (skip) {
+        continue;
+      }
+      const height = 1.1 + ((row * 3 + col) % 4) * 0.45;
+      blocks.push({
+        position: [originX + col * 2.15, height / 2, originZ + row * 1.85],
+        size: [1.7, height, 1.45],
+      });
+    }
+  }
+
+  blocks.push({ position: [-1.2, 2.1, -8.4], size: [3.2, 4.2, 2.4] });
+  blocks.push({ position: [3.4, 1.6, -5.2], size: [2.4, 3.2, 2.1] });
+  return blocks;
+}
+
+export type TerraceStep = {
+  position: [number, number, number];
+  size: [number, number, number];
+};
+
+export function buildTerraceSteps(): TerraceStep[] {
+  const steps: TerraceStep[] = [];
+  for (let index = 0; index < 7; index += 1) {
+    steps.push({
+      position: [10 + index * 2.2, 0.18 + index * 0.08, -2 - index * 1.1],
+      size: [18 - index * 1.1, 0.36, 2.4],
+    });
+  }
+  return steps;
+}

--- a/apps/web/components/landing/machu-picchu-model.tsx
+++ b/apps/web/components/landing/machu-picchu-model.tsx
@@ -41,18 +41,66 @@ function useModelAvailable(url: string): boolean | null {
   return available;
 }
 
+function polishStoneMaterial(
+  source: THREE.Material,
+  quality: SceneQuality,
+): THREE.Material {
+  if (!(source instanceof THREE.MeshStandardMaterial)) {
+    return source;
+  }
+
+  if (quality === "low") {
+    source.roughness = Math.min(source.roughness, 0.62);
+    return source;
+  }
+
+  const next = new THREE.MeshPhysicalMaterial();
+  next.copy(source);
+  next.metalness = Math.min(0.12, source.metalness + 0.04);
+  next.roughness = Math.min(0.42, source.roughness);
+  next.clearcoat = 0.48;
+  next.clearcoatRoughness = 0.32;
+  next.envMapIntensity = 1.15;
+  return next;
+}
+
 function MachuPicchuGltf({ quality }: { readonly quality: SceneQuality }) {
   const { scene } = useGLTF(HERO_SCENE_MODEL_URL);
   const clone = useMemo(() => scene.clone(true), [scene]);
 
   useEffect(() => {
+    const extras: THREE.Material[] = [];
     clone.traverse((child) => {
       if (!(child instanceof THREE.Mesh)) {
         return;
       }
       child.castShadow = quality === "high";
       child.receiveShadow = quality === "high";
+      const source = child.material;
+      if (Array.isArray(source)) {
+        child.material = source.map((entry) => {
+          const next = polishStoneMaterial(entry, quality);
+          if (next !== entry) {
+            extras.push(next);
+          }
+          return next;
+        });
+        return;
+      }
+      if (source) {
+        const next = polishStoneMaterial(source, quality);
+        child.material = next;
+        if (next !== source) {
+          extras.push(next);
+        }
+      }
     });
+
+    return () => {
+      for (const material of extras) {
+        material.dispose();
+      }
+    };
   }, [clone, quality]);
 
   return (
@@ -92,7 +140,7 @@ export function ProceduralMachuPicchu({
   return (
     <group>
       <mesh geometry={terrain} receiveShadow={quality === "high"}>
-        <meshStandardMaterial color="#9aa6b8" roughness={0.86} />
+        <meshStandardMaterial color="#8f9a7a" roughness={0.78} />
       </mesh>
       {blocks.map((block) => (
         <mesh
@@ -102,7 +150,11 @@ export function ProceduralMachuPicchu({
           receiveShadow={quality === "high"}
         >
           <boxGeometry args={block.size} />
-          <meshStandardMaterial color="#f4f7fb" roughness={0.42} />
+          <meshPhysicalMaterial
+            clearcoat={0.55}
+            color="#f4f7fb"
+            roughness={0.32}
+          />
         </mesh>
       ))}
       {terraces.map((step) => (
@@ -112,7 +164,11 @@ export function ProceduralMachuPicchu({
           receiveShadow={quality === "high"}
         >
           <boxGeometry args={step.size} />
-          <meshStandardMaterial color="#d7dde8" roughness={0.55} />
+          <meshPhysicalMaterial
+            clearcoat={0.4}
+            color="#d7dde8"
+            roughness={0.4}
+          />
         </mesh>
       ))}
       <mesh position={[6, 18, -38]}>

--- a/apps/web/components/landing/machu-picchu-model.tsx
+++ b/apps/web/components/landing/machu-picchu-model.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { Center, useGLTF } from "@react-three/drei";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import * as THREE from "three";
+
+import { HERO_SCENE_MODEL_URL } from "@/components/landing/hero-scene";
+import {
+  buildCitadelBlocks,
+  buildTerraceSteps,
+  MACHU_MODEL_SCALE,
+  ridgeHeight,
+} from "@/components/landing/machu-picchu-geometry";
+import { ModelErrorBoundary } from "@/components/landing/model-error-boundary";
+
+type SceneQuality = "low" | "high";
+
+function useModelAvailable(url: string): boolean | null {
+  const [available, setAvailable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(url, { method: "HEAD" })
+      .then((response) => {
+        if (!cancelled) {
+          setAvailable(response.ok);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAvailable(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return available;
+}
+
+function MachuPicchuGltf({ quality }: { readonly quality: SceneQuality }) {
+  const { scene } = useGLTF(HERO_SCENE_MODEL_URL);
+  const clone = useMemo(() => scene.clone(true), [scene]);
+
+  useEffect(() => {
+    clone.traverse((child) => {
+      if (!(child instanceof THREE.Mesh)) {
+        return;
+      }
+      child.castShadow = quality === "high";
+      child.receiveShadow = quality === "high";
+    });
+  }, [clone, quality]);
+
+  return (
+    <Center disableY>
+      <primitive object={clone} scale={MACHU_MODEL_SCALE} />
+    </Center>
+  );
+}
+
+export function ProceduralMachuPicchu({
+  quality,
+}: {
+  readonly quality: SceneQuality;
+}) {
+  const segments = quality === "high" ? 72 : 40;
+  const terrain = useMemo(() => {
+    const next = new THREE.PlaneGeometry(180, 180, segments, segments);
+    next.rotateX(-Math.PI / 2);
+    const position = next.attributes.position;
+    if (!position) {
+      return next;
+    }
+    for (let index = 0; index < position.count; index += 1) {
+      const x = position.getX(index);
+      const z = position.getZ(index);
+      position.setY(index, ridgeHeight(x, z));
+    }
+    next.computeVertexNormals();
+    return next;
+  }, [segments]);
+
+  useEffect(() => () => terrain.dispose(), [terrain]);
+
+  const blocks = useMemo(() => buildCitadelBlocks(), []);
+  const terraces = useMemo(() => buildTerraceSteps(), []);
+
+  return (
+    <group>
+      <mesh geometry={terrain} receiveShadow={quality === "high"}>
+        <meshStandardMaterial color="#9aa6b8" roughness={0.86} />
+      </mesh>
+      {blocks.map((block) => (
+        <mesh
+          castShadow={quality === "high"}
+          key={`${block.position.join("-")}`}
+          position={block.position}
+          receiveShadow={quality === "high"}
+        >
+          <boxGeometry args={block.size} />
+          <meshStandardMaterial color="#f4f7fb" roughness={0.42} />
+        </mesh>
+      ))}
+      {terraces.map((step) => (
+        <mesh
+          key={`${step.position.join("-")}`}
+          position={step.position}
+          receiveShadow={quality === "high"}
+        >
+          <boxGeometry args={step.size} />
+          <meshStandardMaterial color="#d7dde8" roughness={0.55} />
+        </mesh>
+      ))}
+      <mesh position={[6, 18, -38]}>
+        <coneGeometry args={[11, 34, 7]} />
+        <meshStandardMaterial color="#c5cedb" roughness={0.7} />
+      </mesh>
+    </group>
+  );
+}
+
+function GltfOrFallback({
+  quality,
+  fallback,
+}: {
+  readonly quality: SceneQuality;
+  readonly fallback: ReactNode;
+}) {
+  const available = useModelAvailable(HERO_SCENE_MODEL_URL);
+
+  if (available !== true) {
+    return fallback;
+  }
+
+  return (
+    <ModelErrorBoundary fallback={fallback}>
+      <MachuPicchuGltf quality={quality} />
+    </ModelErrorBoundary>
+  );
+}
+
+export function MachuPicchuAsset({
+  quality,
+}: {
+  readonly quality: SceneQuality;
+}) {
+  const fallback = <ProceduralMachuPicchu quality={quality} />;
+
+  return <GltfOrFallback fallback={fallback} quality={quality} />;
+}
+
+useGLTF.preload(HERO_SCENE_MODEL_URL);

--- a/apps/web/components/landing/machu-picchu-scene.tsx
+++ b/apps/web/components/landing/machu-picchu-scene.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { cn } from "@chofex/ui/lib/utils";
+import dynamic from "next/dynamic";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
+
+import type { ProjectedTarget } from "@/components/landing/machu-picchu-geometry";
+import {
+  detectWebGL,
+  prefersReducedMotion,
+  readGpuRenderer,
+  resolveWorldPresentation,
+  type WorldPresentation,
+  type WorldQuality,
+} from "@/components/landing/world-capability";
+
+const MachuPicchuCanvas = dynamic(
+  () =>
+    import("@/components/landing/machu-picchu-canvas").then(
+      (module) => module.MachuPicchuCanvas,
+    ),
+  { ssr: false },
+);
+
+export type MachuPicchuSceneProps = {
+  readonly className?: string;
+  readonly quality?: WorldQuality;
+  readonly forceFallback?: boolean;
+  readonly progressRef: MutableRefObject<number>;
+  readonly onTargets?: (targets: ProjectedTarget[]) => void;
+};
+
+type NavigatorWithMemory = Navigator & { deviceMemory?: number };
+
+function detectPresentation(
+  quality: WorldQuality,
+  forceFallback: boolean,
+): WorldPresentation {
+  const navigatorWithMemory = navigator as NavigatorWithMemory;
+  return resolveWorldPresentation({
+    forceFallback,
+    gpuRenderer: readGpuRenderer(),
+    hasWebGL: detectWebGL(),
+    hardwareConcurrency: navigator.hardwareConcurrency,
+    deviceMemory: navigatorWithMemory.deviceMemory,
+    prefersReducedMotion: prefersReducedMotion(),
+    quality,
+  });
+}
+
+export function MachuPicchuFallback({
+  className,
+}: {
+  readonly className?: string;
+}) {
+  return (
+    <div
+      className={cn("absolute inset-0 overflow-hidden bg-[#0057ff]", className)}
+    >
+      <div className="absolute inset-0 bg-[linear-gradient(180deg,#8ec2ff_0%,#0057ff_38%,#0a2a88_72%,#07122b_100%)]" />
+      <div className="absolute top-[18%] right-[16%] size-24 rounded-full bg-[#e8ff00] blur-[2px]" />
+      <div className="absolute right-[-8%] bottom-[8%] h-[58%] w-[62%] rounded-[46%_40%_20%_60%] bg-[#9aa6b8]" />
+      <div className="absolute right-[18%] bottom-[28%] h-[36%] w-[28%] rounded-[30%] bg-[#f4f7fb]" />
+      <div className="absolute bottom-0 left-0 h-[22%] w-full bg-[#1d3f8a]" />
+    </div>
+  );
+}
+
+/**
+ * Machu Picchu WebGL mount for `HeroScene`.
+ *
+ * Overlay contract:
+ * - Render as children of `#hero-scene`
+ * - This layer is `pointer-events: none` and sits at z-0
+ * - Landing type / CTAs stay in the scroll overlays
+ */
+export function MachuPicchuScene({
+  className,
+  quality = "auto",
+  forceFallback = false,
+  progressRef,
+  onTargets,
+}: MachuPicchuSceneProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [presentation, setPresentation] = useState<WorldPresentation>({
+    mode: "fallback",
+    reason: "ssr",
+  });
+  const [visible, setVisible] = useState(true);
+  const [contextLost, setContextLost] = useState(false);
+
+  useEffect(() => {
+    setPresentation(detectPresentation(quality, forceFallback));
+  }, [forceFallback, quality]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry) {
+          return;
+        }
+        setVisible(entry.isIntersecting);
+      },
+      { threshold: 0.04 },
+    );
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  const webglReady = presentation.mode === "webgl" && !contextLost;
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        "pointer-events-none absolute inset-0 size-full",
+        className,
+      )}
+    >
+      <MachuPicchuFallback />
+      {webglReady ? (
+        <MachuPicchuCanvas
+          onContextLost={() => setContextLost(true)}
+          onTargets={onTargets}
+          progressRef={progressRef}
+          quality={presentation.quality}
+          visible={visible}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/landing/model-error-boundary.tsx
+++ b/apps/web/components/landing/model-error-boundary.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+type ModelErrorBoundaryProps = {
+  readonly children: ReactNode;
+  readonly fallback: ReactNode;
+};
+
+type ModelErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ModelErrorBoundary extends Component<
+  ModelErrorBoundaryProps,
+  ModelErrorBoundaryState
+> {
+  state: ModelErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ModelErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/components/landing/scan-hud.tsx
+++ b/apps/web/components/landing/scan-hud.tsx
@@ -1,0 +1,43 @@
+import type { ProjectedTarget } from "@/components/landing/machu-picchu-geometry";
+
+export function ScanHud({
+  visible,
+  targets,
+}: {
+  readonly visible: boolean;
+  readonly targets: readonly ProjectedTarget[];
+}) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20 overflow-hidden">
+      <div className="landing-halftone" />
+      <div className="landing-scanlines" />
+      <div className="absolute top-28 left-4 font-mono text-[10px] tracking-[0.2em] text-[#e8ff00] uppercase sm:left-8">
+        scan / talento
+      </div>
+      {targets.map((target) => {
+        if (!target.visible) {
+          return null;
+        }
+        return (
+          <div
+            className="landing-scan-box"
+            key={target.id}
+            style={{
+              left: `${target.x}%`,
+              top: `${target.y}%`,
+              width: target.kind === "judge" ? "7.5rem" : "6.2rem",
+              height: target.kind === "judge" ? "9.5rem" : "8rem",
+              transform: "translate(-50%, -70%)",
+            }}
+          >
+            <span className="landing-scan-box__label">{target.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/landing/scan-hud.tsx
+++ b/apps/web/components/landing/scan-hud.tsx
@@ -13,9 +13,9 @@ export function ScanHud({
 
   return (
     <div className="pointer-events-none absolute inset-0 z-20 overflow-hidden">
-      <div className="landing-halftone" />
-      <div className="landing-scanlines" />
-      <div className="absolute top-28 left-4 font-mono text-[10px] tracking-[0.2em] text-[#e8ff00] uppercase sm:left-8">
+      <div className="hud-halftone absolute inset-0 opacity-40" />
+      <div className="hud-scanlines absolute inset-0" />
+      <div className="absolute top-28 left-4 font-[family-name:var(--font-landing-mono)] text-[10px] tracking-[0.2em] text-[#d6ff00] uppercase sm:left-8">
         scan / talento
       </div>
       {targets.map((target) => {

--- a/apps/web/components/landing/world-capability.test.ts
+++ b/apps/web/components/landing/world-capability.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+
+import { isSoftwareGpu, resolveWorldPresentation } from "./world-capability";
+
+test("falls back when WebGL is missing", () => {
+  const presentation = resolveWorldPresentation({
+    hasWebGL: false,
+    prefersReducedMotion: false,
+  });
+  expect(presentation).toEqual({ mode: "fallback", reason: "no-webgl" });
+});
+
+test("falls back for reduced motion even when WebGL is available", () => {
+  const presentation = resolveWorldPresentation({
+    hasWebGL: true,
+    prefersReducedMotion: true,
+  });
+  expect(presentation).toEqual({
+    mode: "fallback",
+    reason: "reduced-motion",
+  });
+});
+
+test("falls back on very low memory devices", () => {
+  const presentation = resolveWorldPresentation({
+    hasWebGL: true,
+    prefersReducedMotion: false,
+    deviceMemory: 2,
+  });
+  expect(presentation).toEqual({ mode: "fallback", reason: "weak-device" });
+});
+
+test("uses a low-quality live scene on software gpus", () => {
+  expect(isSoftwareGpu("Google SwiftShader")).toBe(true);
+  const presentation = resolveWorldPresentation({
+    hasWebGL: true,
+    prefersReducedMotion: false,
+    gpuRenderer: "llvmpipe (LLVM 15.0.0, 256 bits)",
+  });
+  expect(presentation).toEqual({ mode: "webgl", quality: "low" });
+});
+
+test("uses a high-quality live scene when auto and the device is capable", () => {
+  const presentation = resolveWorldPresentation({
+    hasWebGL: true,
+    prefersReducedMotion: false,
+    deviceMemory: 8,
+    hardwareConcurrency: 8,
+    quality: "auto",
+  });
+  expect(presentation).toEqual({ mode: "webgl", quality: "high" });
+});
+
+test("honors an explicit quality pin", () => {
+  const presentation = resolveWorldPresentation({
+    hasWebGL: true,
+    prefersReducedMotion: false,
+    deviceMemory: 8,
+    hardwareConcurrency: 8,
+    quality: "low",
+  });
+  expect(presentation).toEqual({ mode: "webgl", quality: "low" });
+});

--- a/apps/web/components/landing/world-capability.ts
+++ b/apps/web/components/landing/world-capability.ts
@@ -1,0 +1,117 @@
+export type WorldQuality = "auto" | "low" | "high";
+
+export type WorldFallbackReason =
+  | "ssr"
+  | "no-webgl"
+  | "reduced-motion"
+  | "weak-device"
+  | "forced";
+
+export type WorldPresentation =
+  | { mode: "fallback"; reason: WorldFallbackReason }
+  | { mode: "webgl"; quality: "low" | "high" };
+
+const SOFTWARE_GPU =
+  /swiftshader|llvmpipe|softpipe|virtualbox|microsoft basic render|gdi generic/i;
+
+export function detectWebGL(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  try {
+    const canvas = document.createElement("canvas");
+    const context =
+      canvas.getContext("webgl2") ??
+      canvas.getContext("webgl") ??
+      canvas.getContext("experimental-webgl");
+    return context !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function readGpuRenderer(): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  try {
+    const canvas = document.createElement("canvas");
+    const gl =
+      canvas.getContext("webgl2") ??
+      canvas.getContext("webgl") ??
+      canvas.getContext("experimental-webgl");
+    if (!gl || !("getExtension" in gl)) {
+      return undefined;
+    }
+
+    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    if (!debugInfo) {
+      return undefined;
+    }
+
+    const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+    return typeof renderer === "string" ? renderer : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function prefersReducedMotion(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function isSoftwareGpu(renderer: string | undefined): boolean {
+  if (!renderer) {
+    return false;
+  }
+
+  return SOFTWARE_GPU.test(renderer);
+}
+
+export function resolveWorldPresentation(input: {
+  hasWebGL: boolean;
+  prefersReducedMotion: boolean;
+  gpuRenderer?: string;
+  deviceMemory?: number;
+  hardwareConcurrency?: number;
+  quality?: WorldQuality;
+  forceFallback?: boolean;
+}): WorldPresentation {
+  if (input.forceFallback) {
+    return { mode: "fallback", reason: "forced" };
+  }
+
+  if (!input.hasWebGL) {
+    return { mode: "fallback", reason: "no-webgl" };
+  }
+
+  if (input.prefersReducedMotion) {
+    return { mode: "fallback", reason: "reduced-motion" };
+  }
+
+  if ((input.deviceMemory ?? 8) <= 2) {
+    return { mode: "fallback", reason: "weak-device" };
+  }
+
+  if (input.quality === "low" || input.quality === "high") {
+    return { mode: "webgl", quality: input.quality };
+  }
+
+  const software = isSoftwareGpu(input.gpuRenderer);
+  const lowMemory = (input.deviceMemory ?? 8) <= 4;
+  const lowCpu = (input.hardwareConcurrency ?? 8) <= 4;
+  if (software || lowMemory || lowCpu) {
+    return { mode: "webgl", quality: "low" };
+  }
+
+  return { mode: "webgl", quality: "high" };
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  transpilePackages: ["three"],
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "**.blob.vercel-storage.com" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
     "@chofex/ui": "*",
     "@clerk/nextjs": "^7.9.1",
     "@clerk/ui": "^1.32.2",
+    "@react-three/drei": "^10.7.8",
+    "@react-three/fiber": "^9.7.0",
     "@tanstack/react-query": "^5.102.8",
     "@vercel/blob": "^2.8.0",
     "effect": "4.0.0-rc.112",
@@ -25,7 +27,8 @@
     "next-themes": "^0.4.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "three": "^0.186.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.12",

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,8 @@
         "@chofex/ui": "*",
         "@clerk/nextjs": "^7.9.1",
         "@clerk/ui": "^1.32.2",
+        "@react-three/drei": "^10.7.8",
+        "@react-three/fiber": "^9.7.0",
         "@tanstack/react-query": "^5.102.8",
         "@vercel/blob": "^2.8.0",
         "effect": "4.0.0-rc.112",
@@ -64,6 +66,7 @@
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-markdown": "^10.1.0",
+        "three": "^0.186.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.12",
@@ -245,6 +248,8 @@
 
     "@clerk/ui": ["@clerk/ui@1.32.2", "", { "dependencies": { "@clerk/localizations": "^4.16.0", "@clerk/shared": "^4.31.0", "@emotion/cache": "11.11.0", "@emotion/react": "11.11.1", "@floating-ui/react": "0.27.12", "@formkit/auto-animate": "^0.8.2", "@solana/wallet-adapter-base": "0.9.27", "@solana/wallet-adapter-react": "0.15.39", "@solana/wallet-standard": "1.1.4", "@stylexjs/stylex": "0.19.0", "@swc/helpers": "0.5.21", "copy-to-clipboard": "3.3.3", "core-js": "3.47.0", "csstype": "3.1.3", "dequal": "2.0.3", "input-otp": "1.4.2", "qrcode.react": "4.2.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-ZG8+0JwALbptzve+OGvvsn4M83GyjTHyZunlP3xAb3JSfHkMNxBUoELhQET4fVOv11cFUCBXn+LaQVTBo6oD9w=="],
 
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
 
     "@dotenvx/primitives": ["@dotenvx/primitives@0.8.0", "", {}, "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg=="],
@@ -421,7 +426,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.4.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -484,6 +493,10 @@
     "@react-native/normalize-colors": ["@react-native/normalize-colors@0.87.1", "", {}, "sha512-8+AutemzX+a7cuKgTUyb7JUk3sFYgLyrSnlTLrL6LuW/LKDE+FYE8lJGWYhJPJcE51Ge1D8yRzxgQEdEFZtuIw=="],
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.87.1", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.2.0", "react": "*", "react-native": "0.87.1" }, "optionalPeers": ["@types/react"] }, "sha512-qSZjeX3UJrDvyfjf7yc3E68rp1XnzE+5nu8ImklhkVC0+p/XiaHPb/KGkRqDdnQyWHN55BRYSsCMEwgVI6WRNQ=="],
+
+    "@react-three/drei": ["@react-three/drei@10.7.8", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@use-gesture/react": "^10.3.1", "camera-controls": "^3.1.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.8.3", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.4", "tunnel-rat": "^0.1.2", "use-sync-external-store": "^1.4.0", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^9.0.0", "react": "^19", "react-dom": "^19", "three": ">=0.159" }, "optionalPeers": ["react-dom"] }, "sha512-rJXyuzLm2Xq0kafHuR47ajDGbOe/pEhzIr4m8E8zwzQs0iNjloFDqBwRhrXmP/w+onLeYyN3EYPFW/cwWK/4yA=="],
+
+    "@react-three/fiber": ["@react-three/fiber@9.7.0", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-use-measure": "^2.1.7", "scheduler": "^0.27.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": ">=19 <19.3", "react-dom": ">=19 <19.3", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw=="],
 
     "@redis/bloom": ["@redis/bloom@6.2.1", "", { "peerDependencies": { "@redis/client": "^6.2.1" } }, "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag=="],
 
@@ -673,11 +686,15 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
     "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/draco3d": ["@types/draco3d@1.4.10", "", {}, "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
@@ -697,15 +714,25 @@
 
     "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
+    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
+
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
 
+    "@types/react-reconciler": ["@types/react-reconciler@0.28.9", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.185.4", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -755,6 +782,10 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.4.0", "", {}, "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ=="],
 
+    "@use-gesture/core": ["@use-gesture/core@10.3.1", "", {}, "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="],
+
+    "@use-gesture/react": ["@use-gesture/react@10.3.1", "", { "dependencies": { "@use-gesture/core": "10.3.1" }, "peerDependencies": { "react": ">= 16.8.0" } }, "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g=="],
+
     "@vercel/blob": ["@vercel/blob@2.8.0", "", { "dependencies": { "@vercel/oidc": "^3.6.1", "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ=="],
 
     "@vercel/cli-config": ["@vercel/cli-config@0.2.6", "", { "dependencies": { "xdg-app-paths": "5", "zod": "4.1.11" } }, "sha512-2AsKCf6gE/Eniq09ARm1RK9rQMV5pcAHU7BFcR9MISO+4/RsjjkaYbQN6G85/xi9pYZ5CJNXvYn4TI6p1jKBcg=="],
@@ -791,7 +822,7 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -818,6 +849,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ=="],
+
+    "bidi-js": ["bidi-js@1.1.0", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg=="],
 
     "bn.js": ["bn.js@5.2.5", "", {}, "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg=="],
 
@@ -853,7 +886,9 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "camera-controls": ["camera-controls@3.1.2", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
@@ -925,6 +960,8 @@
 
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
+    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-mediaquery": ["css-mediaquery@0.1.2", "", {}, "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="],
@@ -959,6 +996,8 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
+    "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -970,6 +1009,8 @@
     "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "draco3d": ["draco3d@1.5.7", "", {}, "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
@@ -1059,6 +1100,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.6.11", "", {}, "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg=="],
+
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -1103,6 +1146,8 @@
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
+    "glsl-noise": ["glsl-noise@0.0.0", "", {}, "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1122,6 +1167,8 @@
     "hermes-estree": ["hermes-estree@0.36.1", "", {}, "sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw=="],
 
     "hermes-parser": ["hermes-parser@0.36.1", "", { "dependencies": { "hermes-estree": "0.36.1" } }, "sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ=="],
+
+    "hls.js": ["hls.js@1.7.2", "", {}, "sha512-CW/pPvSOFIRsosbwxrYaE9ERmpTo5fbTqL7wCvuCFlqW1Bmb1K5fXsY7yiH95rmlr4rVuA7UXHbM/cIXQ6AXwg=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
@@ -1144,6 +1191,8 @@
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -1195,7 +1244,7 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+    "is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
 
     "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
 
@@ -1208,6 +1257,8 @@
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
+
+    "its-fine": ["its-fine@2.0.0", "", { "dependencies": { "@types/react-reconciler": "^0.28.9" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng=="],
 
     "jayson": ["jayson@4.3.0", "", { "dependencies": { "@types/connect": "^3.4.33", "@types/node": "^12.12.54", "@types/ws": "^7.4.4", "commander": "^2.20.3", "delay": "^5.0.0", "es6-promisify": "^5.0.0", "eyes": "^0.1.8", "isomorphic-ws": "^4.0.1", "json-stringify-safe": "^5.0.1", "stream-json": "^1.9.1", "uuid": "^8.3.2", "ws": "^7.5.10" }, "bin": { "jayson": "bin/jayson.js" } }, "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ=="],
 
@@ -1248,6 +1299,8 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
@@ -1291,6 +1344,8 @@
 
     "lucide-react": ["lucide-react@1.43.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ubtnda1fVK5ky0PNEpOmB0wiwhpZUyJiol4K14KCm+QKvuCkfUu54Et/rIjyupJpwiJ5Hg+BLQE86/GEsS+IgQ=="],
 
+    "maath": ["maath@0.10.8", "", { "peerDependencies": { "@types/three": ">=0.134.0", "three": ">=0.134.0" } }, "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
@@ -1326,6 +1381,10 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "meshline": ["meshline@3.3.1", "", { "peerDependencies": { "three": ">=0.137" } }, "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ=="],
+
+    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
     "metro": ["metro@0.87.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "accepts": "^2.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.36.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.87.0", "metro-cache": "0.87.0", "metro-cache-key": "0.87.0", "metro-config": "0.87.0", "metro-core": "0.87.0", "metro-file-map": "0.87.0", "metro-resolver": "0.87.0", "metro-runtime": "0.87.0", "metro-source-map": "0.87.0", "metro-symbolicate": "0.87.0", "metro-transform-plugins": "0.87.0", "metro-transform-worker": "0.87.0", "mime-types": "^3.0.1", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-fRqFhSzQhLNQSCvJFeuRzBRXAOOKXf1O8d2cvmMtG6yFR0jCllQ7vBsXoLP18yuqtf+N1XwWXTPF11eWy9q6dQ=="],
 
@@ -1505,6 +1564,8 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.6", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw=="],
 
+    "potpack": ["potpack@1.0.2", "", {}, "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="],
+
     "powershell-utils": ["powershell-utils@0.2.1", "", {}, "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A=="],
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
@@ -1512,6 +1573,8 @@
     "pretty-ms": ["pretty-ms@9.3.1", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA=="],
 
     "promise": ["promise@8.3.0", "", { "dependencies": { "asap": "~2.0.6" } }, "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg=="],
+
+    "promise-worker-transferable": ["promise-worker-transferable@1.0.4", "", { "dependencies": { "is-promise": "^2.1.0", "lie": "^3.0.2" } }, "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -1548,6 +1611,8 @@
     "react-native": ["react-native@0.87.1", "", { "dependencies": { "@react-native/asset-utils": "0.87.1", "@react-native/codegen": "0.87.1", "@react-native/community-cli-plugin": "0.87.1", "@react-native/gradle-plugin": "0.87.1", "@react-native/normalize-colors": "0.87.1", "@react-native/virtualized-lists": "0.87.1", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-plugin-syntax-hermes-parser": "0.36.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.17", "invariant": "^2.2.4", "memoize-one": "^5.0.0", "metro-runtime": "^0.87.0", "metro-source-map": "^0.87.0", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-DJKG6ANoD7BtrE4z9DewiSD7/RxCX73lK5Pu49aUr85P3333Dm2roTiP0rRjQNDZdVizHSOmstWfwF/o9EjCRA=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+
+    "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
     "recast": ["recast@0.23.21", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw=="],
 
@@ -1647,6 +1712,10 @@
 
     "standardwebhooks": ["standardwebhooks@1.1.1", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ=="],
 
+    "stats-gl": ["stats-gl@2.4.2", "", { "dependencies": { "@types/three": "*", "three": "^0.170.0" } }, "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ=="],
+
+    "stats.js": ["stats.js@0.17.0", "", {}, "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
@@ -1683,6 +1752,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
+
     "systeminformation": ["systeminformation@5.33.10", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-/NXbMVASt2UbSVgmWto4aBTIAeuYY7zOELpZybmNxqpsrbo5uYHpuEPf5nkyrPng0uG5YOb+Yv6s0FyKY4mDQg=="],
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
@@ -1694,6 +1765,12 @@
     "terser": ["terser@5.51.2", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q=="],
 
     "text-encoding-utf-8": ["text-encoding-utf-8@1.0.2", "", {}, "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="],
+
+    "three": ["three@0.186.0", "", {}, "sha512-cr/fIM2ddMSVbYVgkfD4jLJv7Fh/8ZTjvo+7gQeSVGUZHxpx9FDwoL5iC7hUz/LiRA8wMbqfnb90xKfm1/HHkQ=="],
+
+    "three-mesh-bvh": ["three-mesh-bvh@0.8.3", "", { "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg=="],
+
+    "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
@@ -1715,6 +1792,12 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "troika-three-text": ["troika-three-text@0.52.5", "", { "dependencies": { "bidi-js": "^1.0.2", "troika-three-utils": "^0.52.5", "troika-worker-utils": "^0.52.0", "webgl-sdf-generator": "1.1.1" }, "peerDependencies": { "three": ">=0.125.0" } }, "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA=="],
+
+    "troika-three-utils": ["troika-three-utils@0.52.5", "", { "peerDependencies": { "three": ">=0.125.0" } }, "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw=="],
+
+    "troika-worker-utils": ["troika-worker-utils@0.52.0", "", {}, "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw=="],
+
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
@@ -1724,6 +1807,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.23.13", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw=="],
+
+    "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "turbo": ["turbo@2.10.12", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.12", "@turbo/darwin-arm64": "2.10.12", "@turbo/linux-64": "2.10.12", "@turbo/linux-arm64": "2.10.12", "@turbo/windows-64": "2.10.12", "@turbo/windows-arm64": "2.10.12" }, "bin": { "turbo": "bin/turbo" } }, "sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw=="],
 
@@ -1765,6 +1850,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
+
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
     "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
@@ -1781,6 +1868,10 @@
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
+    "webgl-constants": ["webgl-constants@1.1.1", "", {}, "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="],
+
+    "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
+
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
@@ -1795,7 +1886,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+    "ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "wsl-utils": ["wsl-utils@1.0.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA=="],
 
@@ -1821,6 +1912,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "zustand": ["zustand@5.0.15", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1841,6 +1934,8 @@
 
     "@effect/platform-node/undici": ["undici@8.10.2", "", {}, "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ=="],
 
+    "@effect/platform-node-shared/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
     "@emotion/babel-plugin/@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="],
 
     "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
@@ -1858,8 +1953,6 @@
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
-
-    "@react-native/dev-middleware/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "@solana-mobile/mobile-wallet-adapter-protocol/@noble/curves": ["@noble/curves@2.4.0", "", { "dependencies": { "@noble/hashes": "2.4.0" } }, "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew=="],
 
@@ -1939,6 +2032,8 @@
 
     "@solana/rpc-subscriptions-channel-websocket/@solana/errors": ["@solana/errors@7.1.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "15.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw=="],
 
+    "@solana/rpc-subscriptions-channel-websocket/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
     "@solana/rpc-subscriptions-spec/@solana/errors": ["@solana/errors@7.1.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "15.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw=="],
 
     "@solana/rpc-transformers/@solana/errors": ["@solana/errors@7.1.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "15.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw=="],
@@ -1997,6 +2092,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/three/fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "@vercel/blob/undici": ["undici@6.28.1", "", {}, "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA=="],
 
     "@vercel/cli-config/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
@@ -2037,15 +2134,11 @@
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "jayson/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
-
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2056,8 +2149,6 @@
     "merge-options/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
-
-    "metro/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "metro-source-map/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -2079,19 +2170,23 @@
 
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
-    "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
-
-    "react-native/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "react-native/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
-
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "router/is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "rpc-websockets/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tsx/esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
+
+    "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
@@ -2253,8 +2348,6 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
@@ -2264,8 +2357,6 @@
     "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "jayson/@types/ws/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
@@ -2343,8 +2434,6 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2371,16 +2460,12 @@
 
     "qrcode/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "qrcode/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "qrcode/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto latest `main` after the hero-scene mount landed. The R3F canvas is children of Frontend’s `HeroScene` — no second shell.

## Mount

```tsx
<HeroScene>
  <MachuPicchuScene progressRef={progressRef} onTargets={setTargets} />
</HeroScene>
```

- `#hero-scene`
- `data-hero-scene-theme="machu-picchu"`
- `data-hero-scene-model="/models/machu-picchu.glb"`
- Loader uses exported `HERO_SCENE_MODEL_URL`
- Overlay stays above; canvas is `pointer-events: none`

## Experience

Scroll-driven camera through the real GLB:

1. **Hero** — close cinematic pass over the citadel (cursor look + slow drift), golden-hour key, haze, glossy stone, type sitting on the live scene
2. **Valley** — first judge profile (`QUISPE`) over the gathering
3. **Scan** — bounding-box HUD on figures

`LandingJudges` / `LandingScan` / apply / sponsors below stay as they are on main.

## Notes

- Model file is `apps/web/public/models/machu-picchu.glb` (already on main)
- Reduced-motion / no-WebGL / very low memory → CSS still
- Software GPUs get the low-quality live scene (no sparkles / lighter materials)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97a4d306-fc5e-5680-b326-6ca46b7ff575?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97a4d306-fc5e-5680-b326-6ca46b7ff575&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

