### PR TITLE
fix: wait for the citadel GLB before revealing the hero world

### DIFF
--- a/apps/web/components/landing/machu-picchu-canvas.tsx
+++ b/apps/web/components/landing/machu-picchu-canvas.tsx
@@ -48,20 +48,6 @@ export type MachuPicchuCanvasProps = {
   readonly onTargets?: (targets: ProjectedTarget[]) => void;
 };
 
-function ReportWorldReady({ onReady }: { readonly onReady?: () => void }) {
-  const sent = useRef(false);
-
-  useFrame(() => {
-    if (sent.current || !onReady) {
-      return;
-    }
-    sent.current = true;
-    onReady();
-  });
-
-  return null;
-}
-
 function WorldLights({ quality }: { readonly quality: SceneQuality }) {
   const mapSize = quality === "high" ? 2048 : 512;
 
@@ -312,7 +298,7 @@ function MachuWorld({
   return (
     <>
       <WorldLights quality={quality} />
-      <MachuPicchuAsset quality={quality} />
+      <MachuPicchuAsset onPresented={onWorldReady} quality={quality} />
       <ValleyFigures quality={quality} />
       <DriftDiscs quality={quality} reducedMotion={reducedMotion} />
       <HeroSparkles quality={quality} reducedMotion={reducedMotion} />
@@ -324,7 +310,6 @@ function MachuWorld({
         quality={quality}
         reducedMotion={reducedMotion}
       />
-      <ReportWorldReady onReady={onWorldReady} />
       <AdaptiveDpr pixelated={false} />
     </>
   );

--- a/apps/web/components/landing/machu-picchu-geometry.test.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import { HERO_SCENE_MODEL_URL } from "./hero-scene";
 import {
+  CITADEL_OVERLOOK,
   chapterFromProgress,
   chapterStartProgress,
   MACHU_MODEL_SCALE,
@@ -52,6 +53,23 @@ test("exposes labeled chapter stops for the world rail", () => {
       progress: 0.34,
     }),
   ).toBe(1120);
+});
+
+test("reloads onto the Cumbre citadel overlook", () => {
+  expect(CITADEL_OVERLOOK.chapter).toBe("hero");
+  expect(CITADEL_OVERLOOK.progress).toBe(0);
+  expect(chapterFromProgress(CITADEL_OVERLOOK.progress)).toBe("hero");
+  expect(chapterStartProgress("hero")).toBe(CITADEL_OVERLOOK.progress);
+  expect(WORLD_CHAPTERS[0]).toEqual({
+    id: "hero",
+    label: "Cumbre",
+    progress: 0,
+  });
+
+  const overlook = sampleCameraPath(CITADEL_OVERLOOK.progress);
+  const valley = sampleCameraPath(0.5);
+  expect(overlook.position[1]).toBeGreaterThan(valley.position[1]);
+  expect(overlook.position[2]).toBeGreaterThan(valley.position[2]);
 });
 
 test("keeps the camera path descending into the valley", () => {

--- a/apps/web/components/landing/machu-picchu-geometry.ts
+++ b/apps/web/components/landing/machu-picchu-geometry.ts
@@ -14,15 +14,33 @@ export const MACHU_MODEL_SCALE = 0.036;
 
 export type WorldChapter = "hero" | "valley" | "scan";
 
+/**
+ * Bright-sky citadel overlook. A top-of-page reload keeps `#world` at
+ * progress 0, so first paint lands on Cumbre rather than Valle/Escaneo.
+ */
+export const CITADEL_OVERLOOK = {
+  chapter: "hero",
+  label: "Cumbre",
+  progress: 0,
+} as const satisfies {
+  chapter: WorldChapter;
+  label: string;
+  progress: number;
+};
+
 export const WORLD_CHAPTERS = [
-  { id: "hero", label: "Cumbre", progress: 0 },
+  {
+    id: CITADEL_OVERLOOK.chapter,
+    label: CITADEL_OVERLOOK.label,
+    progress: CITADEL_OVERLOOK.progress,
+  },
   { id: "valley", label: "Valle", progress: 0.34 },
   { id: "scan", label: "Escaneo", progress: 0.64 },
 ] as const;
 
 export function chapterStartProgress(chapter: WorldChapter): number {
   if (chapter === "hero") {
-    return 0;
+    return CITADEL_OVERLOOK.progress;
   }
   if (chapter === "valley") {
     return 0.34;
@@ -69,7 +87,8 @@ const CAMERA_STOPS: ReadonlyArray<{
   frame: CameraKeyframe;
 }> = [
   {
-    progress: 0,
+    // Cumbre: high overlook of the bright citadel against open sky.
+    progress: CITADEL_OVERLOOK.progress,
     frame: { position: [46, 18, 58], lookAt: [2, 9, -4] },
   },
   {

--- a/apps/web/components/landing/machu-picchu-model.tsx
+++ b/apps/web/components/landing/machu-picchu-model.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Center, useGLTF } from "@react-three/drei";
-import { Suspense, useEffect, useMemo } from "react";
+import { useFrame } from "@react-three/fiber";
+import { Suspense, useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
 
 import { HERO_SCENE_MODEL_URL } from "@/components/landing/hero-scene";
@@ -41,7 +42,31 @@ function polishStoneMaterial(
   return next;
 }
 
-function MachuPicchuGltf({ quality }: { readonly quality: SceneQuality }) {
+function ReportCitadelPresented({
+  onPresented,
+}: {
+  readonly onPresented?: () => void;
+}) {
+  const sent = useRef(false);
+
+  useFrame(() => {
+    if (sent.current || !onPresented) {
+      return;
+    }
+    sent.current = true;
+    onPresented();
+  });
+
+  return null;
+}
+
+function MachuPicchuGltf({
+  quality,
+  onPresented,
+}: {
+  readonly quality: SceneQuality;
+  readonly onPresented?: () => void;
+}) {
   const { scene } = useGLTF(HERO_SCENE_MODEL_URL, USE_DRACO, USE_MESHOPT);
   const clone = useMemo(() => scene.clone(true), [scene]);
 
@@ -83,10 +108,12 @@ function MachuPicchuGltf({ quality }: { readonly quality: SceneQuality }) {
   return (
     <Center disableY>
       <primitive object={clone} scale={MACHU_MODEL_SCALE} />
+      <ReportCitadelPresented onPresented={onPresented} />
     </Center>
   );
 }
 
+/** Error-boundary stand-in only. Never treat this as a ready world. */
 export function ProceduralMachuPicchu({
   quality,
 }: {
@@ -158,15 +185,18 @@ export function ProceduralMachuPicchu({
 
 export function MachuPicchuAsset({
   quality,
+  onPresented,
 }: {
   readonly quality: SceneQuality;
+  readonly onPresented?: () => void;
 }) {
   const fallback = <ProceduralMachuPicchu quality={quality} />;
 
   return (
     <ModelErrorBoundary fallback={fallback}>
-      <Suspense fallback={fallback}>
-        <MachuPicchuGltf quality={quality} />
+      {/* Keep the rocky stand-in off-screen; painted fallback covers load. */}
+      <Suspense fallback={null}>
+        <MachuPicchuGltf onPresented={onPresented} quality={quality} />
       </Suspense>
     </ModelErrorBoundary>
   );

--- a/apps/web/components/landing/machu-picchu-scene.tsx
+++ b/apps/web/components/landing/machu-picchu-scene.tsx
@@ -80,6 +80,7 @@ export function MachuPicchuFallback({
  * - Render as children of `#hero-scene`
  * - Look layer accepts constrained drag; CTAs keep their own hit targets
  * - Landing type / CTAs stay in the scroll overlays
+ * - Painted fallback stays until the citadel GLB is on a presented frame
  */
 export function MachuPicchuScene({
   className,
@@ -151,6 +152,7 @@ export function MachuPicchuScene({
     documentVisible,
     reducedMotion,
   });
+  const citadelReady = worldReady && webglReady;
 
   return (
     <div
@@ -159,6 +161,7 @@ export function MachuPicchuScene({
         "pointer-events-none absolute inset-0 size-full",
         className,
       )}
+      data-world-reveal={citadelReady ? "citadel" : "pending"}
     >
       {webglReady ? (
         <MachuPicchuCanvas
@@ -171,9 +174,7 @@ export function MachuPicchuScene({
           visible={visible}
         />
       ) : null}
-      <MachuPicchuFallback
-        className={paintedFallbackClassName(worldReady && webglReady)}
-      />
+      <MachuPicchuFallback className={paintedFallbackClassName(citadelReady)} />
     </div>
   );
 }

--- a/apps/web/components/landing/world-reveal.test.ts
+++ b/apps/web/components/landing/world-reveal.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import {
   isPaintedFallbackVisible,
+  isWorldReadyToReveal,
   paintedFallbackClassName,
 } from "./world-reveal";
 
@@ -15,4 +16,11 @@ test("fades the painted fallback only after the world is ready", () => {
   expect(paintedFallbackClassName(true)).toBe(
     "landing-world-fallback landing-world-fallback--ready",
   );
+});
+
+test("treats only the presented citadel GLB as a ready world", () => {
+  expect(isWorldReadyToReveal("pending")).toBe(false);
+  expect(isWorldReadyToReveal("canvas")).toBe(false);
+  expect(isWorldReadyToReveal("procedural")).toBe(false);
+  expect(isWorldReadyToReveal("citadel")).toBe(true);
 });

--- a/apps/web/components/landing/world-reveal.ts
+++ b/apps/web/components/landing/world-reveal.ts
@@ -1,4 +1,14 @@
-/** Painted fallback stays up until the first WebGL world frame exists. */
+/** Signals that can try to hide the painted hero fallback. */
+export type WorldRevealSignal = "pending" | "canvas" | "procedural" | "citadel";
+
+/**
+ * Painted fallback stays up until the citadel GLB is presented.
+ * A first Canvas frame or the rocky procedural stand-in is not ready.
+ */
+export function isWorldReadyToReveal(signal: WorldRevealSignal): boolean {
+  return signal === "citadel";
+}
+
 export function isPaintedFallbackVisible(worldReady: boolean): boolean {
   return !worldReady;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #26

The painted hero fallback was fading on the first Canvas frame. Suspense could still be showing the rocky procedural stand-in while `/models/machu-picchu.glb` decoded, so the first “ready” look was a dark unfinished ridge instead of the citadel.

## Change

- `onWorldReady` now fires from inside the GLB mesh, after the first presented frame — not from a sibling `useFrame` that runs during Suspense.
- Suspense no longer mounts the procedural ridge. That mesh stays error-boundary-only.
- Painted fallback (`landing-world-fallback`) stays opaque until `data-world-reveal="citadel"`.
- Cumbre (`hero`, progress 0) is documented as the bright-sky overlook a top-of-page reload lands on.

## No regressions

- #7 reduced-motion still uses the static painted fallback (no WebGL loop).
- #13 off-screen / hidden-tab still gates `frameloop`.
- #9 look orbit and CTA hit targets are unchanged.
- #14 chapter rail mapping is unchanged.
- #23 preload + compressed GLB path is unchanged.

## Verify

- `bun test apps/web/components/landing`
- `bun run lint` in `apps/web`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eca38a-b8d0-5f0e-a0c5-50f05d00c01d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eca38a-b8d0-5f0e-a0c5-50f05d00c01d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

