### PR TITLE
fix: landing dates and prize counters

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { shadcn } from "@clerk/ui/themes";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { DocumentLang } from "@/components/document-lang";
+import { metadataCopy } from "@/components/landing/content";
 import { QueryProvider } from "@/components/query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import "@chofex/ui/globals.css";
@@ -17,24 +18,20 @@ const geistMono = localFont({
   variable: "--font-geist-mono",
 });
 
-const siteTitle = "Hack the Andes";
-const siteDescription =
-  "Hackathon selectivo de IA en Lima, 10–11 de octubre 2026. Aplica con la CLI o con tu agent.";
-
 export const metadata: Metadata = {
-  title: siteTitle,
-  description: siteDescription,
+  title: metadataCopy.title,
+  description: metadataCopy.description,
   openGraph: {
-    title: siteTitle,
-    description: siteDescription,
+    title: metadataCopy.title,
+    description: metadataCopy.description,
     locale: "es_PE",
-    siteName: siteTitle,
+    siteName: metadataCopy.title,
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: siteTitle,
-    description: siteDescription,
+    title: metadataCopy.title,
+    description: metadataCopy.description,
   },
 };
 

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -27,7 +27,7 @@ export default function OpenGraphImage() {
         }}
       >
         <div style={{ display: "flex" }}>Hackathon selectivo de IA</div>
-        <div style={{ display: "flex" }}>Lima · 10-11 oct 2026</div>
+        <div style={{ display: "flex" }}>Lima · 17–18 oct 2026</div>
       </div>
       <div style={{ display: "flex", flexDirection: "column" }}>
         <div style={{ display: "flex", fontSize: 108, lineHeight: 1 }}>

--- a/apps/web/components/landing/content.test.ts
+++ b/apps/web/components/landing/content.test.ts
@@ -3,10 +3,12 @@ import { expect, test } from "bun:test";
 import {
   applyCopy,
   expeditionSignals,
+  facts,
   footerCopy,
   formatSoles,
   heroCopy,
   hudChrome,
+  metadataCopy,
   prizeAmountsPen,
   prizeAmountsUsd,
   scanCopy,
@@ -17,6 +19,24 @@ import {
   whyCopy,
   worldChapters,
 } from "./content";
+
+test("publishes the 17–18 octubre 2026 weekend in participant-facing copy", () => {
+  const cuando = facts.find((fact) => fact.label === "Cuándo");
+  expect(cuando?.value).toBe("17–18 oct 2026");
+  expect(metadataCopy.description).toContain("17–18 de octubre 2026");
+  expect(heroCopy.meta).toContain("17–18 oct 2026");
+  expect(heroCopy.ctaMeta).toContain("17–18 oct 2026");
+  expect(footerCopy.meta).toContain("17–18 oct 2026");
+
+  const blob = JSON.stringify({
+    facts,
+    footerCopy,
+    heroCopy,
+    metadataCopy,
+  });
+  expect(blob).not.toMatch(/10–11/);
+  expect(blob).not.toMatch(/10-11/);
+});
 
 test("converts published USD prizes to soles at the documented rate", () => {
   expect(usdToPenRate).toBe(3.35);

--- a/apps/web/components/landing/content.ts
+++ b/apps/web/components/landing/content.ts
@@ -34,7 +34,7 @@ export const brandName = "Hack the Andes";
 export const metadataCopy = {
   title: brandName,
   description:
-    "Hackathon selectivo de IA en Lima, 10–11 de octubre 2026. Aplica con la CLI o con tu agent.",
+    "Hackathon selectivo de IA en Lima, 17–18 de octubre 2026. Aplica con la CLI o con tu agent.",
 } as const;
 
 export const cliCommands = [
@@ -69,7 +69,7 @@ export const worldChapters = [
 ] as const;
 
 export const facts = [
-  { label: "Cuándo", value: "10–11 oct 2026" },
+  { label: "Cuándo", value: "17–18 oct 2026" },
   { label: "Dónde", value: "Lima, Perú · presencial" },
   { label: "Equipos", value: "1–4 personas · solos OK" },
   { label: "Duración", value: "~30 horas" },
@@ -82,9 +82,9 @@ export const heroCopy = {
   titleLead: "Hack the",
   titleAccent: "Andes",
   lede: "No vienes a mirar. Vienes a construir.",
-  meta: "Hackathon selectivo de IA · Lima, Perú · 10–11 oct 2026",
+  meta: "Hackathon selectivo de IA · Lima, Perú · 17–18 oct 2026",
   cta: "Aplicar ahora",
-  ctaMeta: "10–11 oct 2026 · presencial",
+  ctaMeta: "17–18 oct 2026 · presencial",
   sponsor: "con el apoyo de chofex",
   skipToWhy: "Bajar a por qué entrar",
 } as const;
@@ -195,7 +195,7 @@ export const sponsorsCopy = {
 } as const;
 
 export const footerCopy = {
-  meta: "lima · 10–11 oct 2026 · con el apoyo de chofex",
+  meta: "lima · 17–18 oct 2026 · con el apoyo de chofex",
   legalLabel: "Legal",
   terms: "Términos",
   privacy: "Privacidad",

--- a/apps/web/components/landing/prize-counter.test.ts
+++ b/apps/web/components/landing/prize-counter.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+
+import { formatSoles } from "./content";
+import {
+  formatPrizeAmount,
+  isRectInViewport,
+  shouldStartPrizeCounter,
+} from "./prize-counter";
+
+test("formats the accessible prize amount without counting up", () => {
+  const numbered = formatPrizeAmount(6_700, "number");
+  expect(numbered).toContain("6");
+  expect(numbered).toContain("700");
+  expect(formatPrizeAmount(1_675, "soles")).toBe(formatSoles(1_675));
+});
+
+test("treats a node already on screen as in view", () => {
+  expect(
+    isRectInViewport(
+      { top: 80, right: 400, bottom: 160, left: 24 },
+      { width: 1280, height: 720 },
+    ),
+  ).toBe(true);
+  expect(
+    isRectInViewport(
+      { top: 800, right: 400, bottom: 880, left: 24 },
+      { width: 1280, height: 720 },
+    ),
+  ).toBe(false);
+});
+
+test("shows the final amount immediately when motion is reduced", () => {
+  expect(
+    shouldStartPrizeCounter({
+      reducedMotion: true,
+      intersecting: false,
+      alreadyInViewport: false,
+    }),
+  ).toBe("final");
+});
+
+test("starts as soon as the node is intersecting or already in view", () => {
+  expect(
+    shouldStartPrizeCounter({
+      reducedMotion: false,
+      intersecting: true,
+      alreadyInViewport: false,
+    }),
+  ).toBe("play");
+  expect(
+    shouldStartPrizeCounter({
+      reducedMotion: false,
+      intersecting: false,
+      alreadyInViewport: true,
+    }),
+  ).toBe("play");
+  expect(
+    shouldStartPrizeCounter({
+      reducedMotion: false,
+      intersecting: false,
+      alreadyInViewport: false,
+    }),
+  ).toBe("wait");
+});

--- a/apps/web/components/landing/prize-counter.tsx
+++ b/apps/web/components/landing/prize-counter.tsx
@@ -6,9 +6,47 @@ import { formatSoles } from "@/components/landing/content";
 
 const DURATION_MS = 1600;
 
+export type PrizeCounterFormat = "soles" | "number";
+
 interface PrizeCounterProps {
   readonly amount: number;
-  readonly format?: "soles" | "number";
+  readonly format?: PrizeCounterFormat;
+}
+
+export function formatPrizeAmount(
+  amount: number,
+  format: PrizeCounterFormat,
+): string {
+  if (format === "number") {
+    return amount.toLocaleString("es-PE");
+  }
+
+  return formatSoles(amount);
+}
+
+export function isRectInViewport(
+  rect: Pick<DOMRect, "top" | "right" | "bottom" | "left">,
+  viewport: { readonly width: number; readonly height: number },
+): boolean {
+  const horizontallyVisible = rect.left < viewport.width && rect.right > 0;
+  const verticallyVisible = rect.top < viewport.height && rect.bottom > 0;
+  return horizontallyVisible && verticallyVisible;
+}
+
+export function shouldStartPrizeCounter(input: {
+  readonly reducedMotion: boolean;
+  readonly intersecting: boolean;
+  readonly alreadyInViewport: boolean;
+}): "final" | "play" | "wait" {
+  if (input.reducedMotion) {
+    return "final";
+  }
+
+  if (input.intersecting || input.alreadyInViewport) {
+    return "play";
+  }
+
+  return "wait";
 }
 
 export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
@@ -22,8 +60,17 @@ export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
     const reducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+    const alreadyInViewport = isRectInViewport(node.getBoundingClientRect(), {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+    const start = shouldStartPrizeCounter({
+      reducedMotion,
+      intersecting: false,
+      alreadyInViewport,
+    });
 
-    if (reducedMotion) {
+    if (start === "final") {
       setValue(amount);
       return;
     }
@@ -34,19 +81,28 @@ export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
     const play = () => {
       if (started) return;
       started = true;
-      const start = performance.now();
+      const began = performance.now();
 
       const tick = (now: number) => {
-        const progress = Math.min(1, (now - start) / DURATION_MS);
+        const progress = Math.min(1, (now - began) / DURATION_MS);
         const eased = 1 - (1 - progress) ** 3;
         setValue(Math.round(amount * eased));
         if (progress < 1) {
           frame = requestAnimationFrame(tick);
+        } else {
+          setValue(amount);
         }
       };
 
       frame = requestAnimationFrame(tick);
     };
+
+    if (start === "play" || typeof IntersectionObserver === "undefined") {
+      play();
+      return () => {
+        cancelAnimationFrame(frame);
+      };
+    }
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -60,17 +116,29 @@ export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
 
     observer.observe(node);
 
+    const queued = observer.takeRecords();
+    if (
+      shouldStartPrizeCounter({
+        reducedMotion: false,
+        intersecting: queued.some((entry) => entry.isIntersecting),
+        alreadyInViewport,
+      }) === "play"
+    ) {
+      play();
+      observer.disconnect();
+    }
+
     return () => {
       observer.disconnect();
       cancelAnimationFrame(frame);
     };
   }, [amount]);
 
-  const formatted =
-    format === "number" ? value.toLocaleString("es-PE") : formatSoles(value);
+  const formatted = formatPrizeAmount(value, format);
+  const accessible = formatPrizeAmount(amount, format);
 
   return (
-    <span ref={nodeRef} className="tabular-nums">
+    <span ref={nodeRef} className="tabular-nums" aria-label={accessible}>
       {formatted}
     </span>
   );

--- a/apps/web/components/landing/prize-counter.tsx
+++ b/apps/web/components/landing/prize-counter.tsx
@@ -138,8 +138,9 @@ export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
   const accessible = formatPrizeAmount(amount, format);
 
   return (
-    <span ref={nodeRef} className="tabular-nums" aria-label={accessible}>
-      {formatted}
+    <span ref={nodeRef} className="tabular-nums">
+      <span aria-hidden="true">{formatted}</span>
+      <span className="sr-only">{accessible}</span>
     </span>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two participant-facing landing bugs.

## Dates
Every marketing date string now uses **17–18 oct 2026** / **17–18 de octubre 2026**:
- `metadataCopy`, facts, hero meta/CTA, footer
- root metadata (reads `metadataCopy`)
- Open Graph / Twitter share image

A content unit test locks the weekend and rejects the old 10–11 strings.

## Prize counters
Counters no longer depend only on a late IntersectionObserver callback:
- `prefers-reduced-motion: reduce` shows the final amount immediately
- On mount, `getBoundingClientRect` / `takeRecords` start the animation if the node is already on screen
- Missing `IntersectionObserver` still plays
- Cleanup cancels the frame and disconnects the observer; effect depends on `amount`
- A visually hidden final amount is the accessible text, so assistive tech never hears zero mid-count

Prize math is unchanged: **6700 / 1675 / 1005** at **3.35**. `LandingPrizes` still passes those amounts into `PrizeCounter`.

## Commits
- `fix: publish 17–18 octubre 2026 in landing copy`
- `fix: start prize counters when already in view`
- `fix: keep prize amounts readable while counters animate`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdab48ea-ad10-5b83-9869-fdac3cba44b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdab48ea-ad10-5b83-9869-fdac3cba44b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

