### PR TITLE
fix: wait for the citadel to be centered before revealing

### DIFF
--- a/apps/web/components/landing/machu-picchu-model.tsx
+++ b/apps/web/components/landing/machu-picchu-model.tsx
@@ -2,7 +2,14 @@
 
 import { Center, useGLTF } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { Suspense, useEffect, useMemo, useRef } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import * as THREE from "three";
 
 import { HERO_SCENE_MODEL_URL } from "@/components/landing/hero-scene";
@@ -13,6 +20,7 @@ import {
   ridgeHeight,
 } from "@/components/landing/machu-picchu-geometry";
 import { ModelErrorBoundary } from "@/components/landing/model-error-boundary";
+import { isCitadelPresented } from "@/components/landing/world-reveal";
 
 type SceneQuality = "low" | "high";
 
@@ -44,13 +52,26 @@ function polishStoneMaterial(
 
 function ReportCitadelPresented({
   onPresented,
+  ready,
 }: {
   readonly onPresented?: () => void;
+  readonly ready: boolean;
 }) {
   const sent = useRef(false);
+  const presentedFrames = useRef(0);
 
   useFrame(() => {
-    if (sent.current || !onPresented) {
+    if (sent.current || !onPresented || !ready) {
+      return;
+    }
+    presentedFrames.current += 1;
+    if (
+      !isCitadelPresented({
+        glbLoaded: true,
+        centered: ready,
+        presentedFrames: presentedFrames.current,
+      })
+    ) {
       return;
     }
     sent.current = true;
@@ -69,6 +90,10 @@ function MachuPicchuGltf({
 }) {
   const { scene } = useGLTF(HERO_SCENE_MODEL_URL, USE_DRACO, USE_MESHOPT);
   const clone = useMemo(() => scene.clone(true), [scene]);
+  const [centered, setCentered] = useState(false);
+  const markCentered = useCallback(() => {
+    setCentered(true);
+  }, []);
 
   useEffect(() => {
     const extras: THREE.Material[] = [];
@@ -106,9 +131,9 @@ function MachuPicchuGltf({
   }, [clone, quality]);
 
   return (
-    <Center disableY>
+    <Center disableY onCentered={markCentered}>
       <primitive object={clone} scale={MACHU_MODEL_SCALE} />
-      <ReportCitadelPresented onPresented={onPresented} />
+      <ReportCitadelPresented onPresented={onPresented} ready={centered} />
     </Center>
   );
 }

--- a/apps/web/components/landing/world-reveal.test.ts
+++ b/apps/web/components/landing/world-reveal.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import {
+  isCitadelPresented,
   isPaintedFallbackVisible,
   isWorldReadyToReveal,
   paintedFallbackClassName,
@@ -22,5 +23,30 @@ test("treats only the presented citadel GLB as a ready world", () => {
   expect(isWorldReadyToReveal("pending")).toBe(false);
   expect(isWorldReadyToReveal("canvas")).toBe(false);
   expect(isWorldReadyToReveal("procedural")).toBe(false);
+  expect(isWorldReadyToReveal("uncentered")).toBe(false);
   expect(isWorldReadyToReveal("citadel")).toBe(true);
+});
+
+test("waits for the citadel to be centered and drawn before reveal", () => {
+  expect(
+    isCitadelPresented({
+      glbLoaded: true,
+      centered: false,
+      presentedFrames: 4,
+    }),
+  ).toBe(false);
+  expect(
+    isCitadelPresented({
+      glbLoaded: true,
+      centered: true,
+      presentedFrames: 1,
+    }),
+  ).toBe(false);
+  expect(
+    isCitadelPresented({
+      glbLoaded: true,
+      centered: true,
+      presentedFrames: 2,
+    }),
+  ).toBe(true);
 });

--- a/apps/web/components/landing/world-reveal.ts
+++ b/apps/web/components/landing/world-reveal.ts
@@ -1,12 +1,26 @@
 /** Signals that can try to hide the painted hero fallback. */
-export type WorldRevealSignal = "pending" | "canvas" | "procedural" | "citadel";
+export type WorldRevealSignal =
+  | "pending"
+  | "canvas"
+  | "procedural"
+  | "uncentered"
+  | "citadel";
 
 /**
- * Painted fallback stays up until the citadel GLB is presented.
- * A first Canvas frame or the rocky procedural stand-in is not ready.
+ * Painted fallback stays up until the citadel GLB is centered and drawn.
+ * A first Canvas frame, the rocky procedural stand-in, or the uncentered
+ * source mesh is not ready.
  */
 export function isWorldReadyToReveal(signal: WorldRevealSignal): boolean {
   return signal === "citadel";
+}
+
+export function isCitadelPresented(input: {
+  glbLoaded: boolean;
+  centered: boolean;
+  presentedFrames: number;
+}): boolean {
+  return input.glbLoaded && input.centered && input.presentedFrames >= 2;
 }
 
 export function isPaintedFallbackVisible(worldReady: boolean): boolean {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continues #26 (already closed by #28). Does not re-close it.

World-layer gate only. Overlay chrome is not hiding-until-ready — the painted fallback in `MachuPicchuScene` stays up until the citadel GLB is loaded, centered, and drawn.

## Why this follow-up

#28 stopped `onWorldReady` from firing on the first Canvas / Suspense frame. `Center` still applies its offset after mount, so a first-frame fade can show a dark close-up of the uncentered mesh.

## Change

- Fade only after `Center.onCentered` and two presented frames.
- Suspense still does not mount the rocky procedural stand-in.

## Verify

- `bun test apps/web/components/landing` — 33 pass
- `bun run lint` in `apps/web`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eca38a-b8d0-5f0e-a0c5-50f05d00c01d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eca38a-b8d0-5f0e-a0c5-50f05d00c01d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

