### PR TITLE
fix: show final prize amounts on first paint

### DIFF
--- a/apps/web/components/landing/prize-counter.test.ts
+++ b/apps/web/components/landing/prize-counter.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { formatSoles, prizeAmountsPen } from "./content";
-import { formatPrizeAmount } from "./prize-counter";
+import { formatPrizeAmount, PrizeCounter } from "./prize-counter";
 
 test("formats the accessible prize amount without counting up", () => {
   const numbered = formatPrizeAmount(6_700, "number");
@@ -23,4 +25,22 @@ test("formats first and second place as the final amounts, not zero", () => {
   expect(formatPrizeAmount(prizeAmountsPen.second, "soles")).not.toBe(
     formatPrizeAmount(0, "soles"),
   );
+});
+
+test("server markup paints final prize amounts, not zero", () => {
+  const first = renderToStaticMarkup(
+    createElement(PrizeCounter, {
+      amount: prizeAmountsPen.first,
+      format: "number",
+    }),
+  );
+  const second = renderToStaticMarkup(
+    createElement(PrizeCounter, { amount: prizeAmountsPen.second }),
+  );
+
+  expect(first).toContain(formatPrizeAmount(6_700, "number"));
+  expect(first).not.toBe(formatPrizeAmount(0, "number"));
+  expect(first).not.toContain(`>${formatPrizeAmount(0, "number")}<`);
+  expect(second).toContain(formatSoles(1_675));
+  expect(second).not.toContain(formatSoles(0));
 });

--- a/apps/web/components/landing/prize-counter.test.ts
+++ b/apps/web/components/landing/prize-counter.test.ts
@@ -1,11 +1,7 @@
 import { expect, test } from "bun:test";
 
-import { formatSoles } from "./content";
-import {
-  formatPrizeAmount,
-  isRectInViewport,
-  shouldStartPrizeCounter,
-} from "./prize-counter";
+import { formatSoles, prizeAmountsPen } from "./content";
+import { formatPrizeAmount } from "./prize-counter";
 
 test("formats the accessible prize amount without counting up", () => {
   const numbered = formatPrizeAmount(6_700, "number");
@@ -14,51 +10,17 @@ test("formats the accessible prize amount without counting up", () => {
   expect(formatPrizeAmount(1_675, "soles")).toBe(formatSoles(1_675));
 });
 
-test("treats a node already on screen as in view", () => {
-  expect(
-    isRectInViewport(
-      { top: 80, right: 400, bottom: 160, left: 24 },
-      { width: 1280, height: 720 },
-    ),
-  ).toBe(true);
-  expect(
-    isRectInViewport(
-      { top: 800, right: 400, bottom: 880, left: 24 },
-      { width: 1280, height: 720 },
-    ),
-  ).toBe(false);
-});
-
-test("shows the final amount immediately when motion is reduced", () => {
-  expect(
-    shouldStartPrizeCounter({
-      reducedMotion: true,
-      intersecting: false,
-      alreadyInViewport: false,
-    }),
-  ).toBe("final");
-});
-
-test("starts as soon as the node is intersecting or already in view", () => {
-  expect(
-    shouldStartPrizeCounter({
-      reducedMotion: false,
-      intersecting: true,
-      alreadyInViewport: false,
-    }),
-  ).toBe("play");
-  expect(
-    shouldStartPrizeCounter({
-      reducedMotion: false,
-      intersecting: false,
-      alreadyInViewport: true,
-    }),
-  ).toBe("play");
-  expect(
-    shouldStartPrizeCounter({
-      reducedMotion: false,
-      intersecting: false,
-      alreadyInViewport: false,
-    }),
-  ).toBe("wait");
+test("formats first and second place as the final amounts, not zero", () => {
+  expect(formatPrizeAmount(prizeAmountsPen.first, "number")).toBe(
+    formatPrizeAmount(6_700, "number"),
+  );
+  expect(formatPrizeAmount(prizeAmountsPen.second, "soles")).toBe(
+    formatSoles(1_675),
+  );
+  expect(formatPrizeAmount(prizeAmountsPen.first, "number")).not.toBe(
+    formatPrizeAmount(0, "number"),
+  );
+  expect(formatPrizeAmount(prizeAmountsPen.second, "soles")).not.toBe(
+    formatPrizeAmount(0, "soles"),
+  );
 });

--- a/apps/web/components/landing/prize-counter.tsx
+++ b/apps/web/components/landing/prize-counter.tsx
@@ -1,10 +1,4 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
-
 import { formatSoles } from "@/components/landing/content";
-
-const DURATION_MS = 1600;
 
 export type PrizeCounterFormat = "soles" | "number";
 
@@ -24,123 +18,8 @@ export function formatPrizeAmount(
   return formatSoles(amount);
 }
 
-export function isRectInViewport(
-  rect: Pick<DOMRect, "top" | "right" | "bottom" | "left">,
-  viewport: { readonly width: number; readonly height: number },
-): boolean {
-  const horizontallyVisible = rect.left < viewport.width && rect.right > 0;
-  const verticallyVisible = rect.top < viewport.height && rect.bottom > 0;
-  return horizontallyVisible && verticallyVisible;
-}
-
-export function shouldStartPrizeCounter(input: {
-  readonly reducedMotion: boolean;
-  readonly intersecting: boolean;
-  readonly alreadyInViewport: boolean;
-}): "final" | "play" | "wait" {
-  if (input.reducedMotion) {
-    return "final";
-  }
-
-  if (input.intersecting || input.alreadyInViewport) {
-    return "play";
-  }
-
-  return "wait";
-}
-
 export function PrizeCounter({ amount, format = "soles" }: PrizeCounterProps) {
-  const nodeRef = useRef<HTMLSpanElement>(null);
-  const [value, setValue] = useState(0);
-
-  useEffect(() => {
-    const node = nodeRef.current;
-    if (node === null) return;
-
-    const reducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    const alreadyInViewport = isRectInViewport(node.getBoundingClientRect(), {
-      width: window.innerWidth,
-      height: window.innerHeight,
-    });
-    const start = shouldStartPrizeCounter({
-      reducedMotion,
-      intersecting: false,
-      alreadyInViewport,
-    });
-
-    if (start === "final") {
-      setValue(amount);
-      return;
-    }
-
-    let frame = 0;
-    let started = false;
-
-    const play = () => {
-      if (started) return;
-      started = true;
-      const began = performance.now();
-
-      const tick = (now: number) => {
-        const progress = Math.min(1, (now - began) / DURATION_MS);
-        const eased = 1 - (1 - progress) ** 3;
-        setValue(Math.round(amount * eased));
-        if (progress < 1) {
-          frame = requestAnimationFrame(tick);
-        } else {
-          setValue(amount);
-        }
-      };
-
-      frame = requestAnimationFrame(tick);
-    };
-
-    if (start === "play" || typeof IntersectionObserver === "undefined") {
-      play();
-      return () => {
-        cancelAnimationFrame(frame);
-      };
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          play();
-          observer.disconnect();
-        }
-      },
-      { threshold: 0.35 },
-    );
-
-    observer.observe(node);
-
-    const queued = observer.takeRecords();
-    if (
-      shouldStartPrizeCounter({
-        reducedMotion: false,
-        intersecting: queued.some((entry) => entry.isIntersecting),
-        alreadyInViewport,
-      }) === "play"
-    ) {
-      play();
-      observer.disconnect();
-    }
-
-    return () => {
-      observer.disconnect();
-      cancelAnimationFrame(frame);
-    };
-  }, [amount]);
-
-  const formatted = formatPrizeAmount(value, format);
-  const accessible = formatPrizeAmount(amount, format);
-
   return (
-    <span ref={nodeRef} className="tabular-nums">
-      <span aria-hidden="true">{formatted}</span>
-      <span className="sr-only">{accessible}</span>
-    </span>
+    <span className="tabular-nums">{formatPrizeAmount(amount, format)}</span>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Premios counters initialized at `0`, so production first paint showed `0` / `S/. 0` for 1st and 2nd place before the count-up reached 6700 / 1675. Assistive text was already the final amount; the visible digits were not.

## Fix

Render the settled `amount` on first paint. No client `useState(0)` and no count-up, so SSR, hydration, and later visits never leave a readable 0 on screen. `aria` is the visible formatted amount.

Prize math in `content.ts` is unchanged.

## Verification

- `bun test ./apps/web/components/landing/prize-counter.test.ts` (includes SSR markup)
- `bun run lint` in `apps/web`
- Static render of `LandingPrizes` paints `6,700` and `S/. 1,675`, not `0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4adf5f40-795b-5b7f-b817-40948195774e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4adf5f40-795b-5b7f-b817-40948195774e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

